### PR TITLE
Feature/volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c
 To create a valid GCS path, remove *https://storage.googleapis.com/* and replace *%20* with a space.
 The resulting GCS path is: risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/Template Library/Global Assets/welcome.mp4.
 - **non-editable**: ( empty / optional ): If present, it indicates this component is not available for customization in the template editor.
+- **volume**: ( integer ): An optional integer value between 0 and 100 that indicated the volume to use when playing video files with audio tracks. If not provided, the value will default to `0` and the video will be muted.
 
 ### Events
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-video",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Web component for playing video files on a Rise Vision Template page",
   "scripts": {
     "prebuild": "eslint .",

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -256,6 +256,8 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
 
     const normalizedVolume = clampNumber( volume, 0, 100 );
 
+    this.volume = normalizedVolume;
+
     // TODO: Check for valid display id
 
     if ( normalizedVolume === 0 ) {

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -258,8 +258,6 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
 
     this.volume = normalizedVolume;
 
-    // TODO: Check for valid display id
-
     if ( normalizedVolume === 0 ) {
       this._muteVideo();
     } else {

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -4,7 +4,7 @@
 import { html } from "@polymer/polymer";
 import { RiseElement } from "rise-common-component/src/rise-element.js";
 import { LoggerMixin } from "rise-common-component/src/logger-mixin";
-import { getVideoFileType, getAspectRatio } from "./utils";
+import { clampNumber, getVideoFileType, getAspectRatio } from "./utils";
 import {} from "./videojs/videojs-css";
 
 const MAX_DECODE_RETRIES = 5;
@@ -43,6 +43,10 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
         type: Boolean,
         value: false
       },
+      volume: {
+        type: Number,
+        value: 0,
+      },
       // Used during testing to allow player initialization to be
       // deferred until stubs, etc.. are in place
       skipPlayerInit: {
@@ -50,6 +54,12 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
         value: false
       }
     }
+  }
+
+  static get observers() {
+    return [
+      "_setVolume(volume)"
+    ]
   }
 
   constructor() {
@@ -187,6 +197,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
       fluid: false,
     }, this._onPlayerInstanceReady );
 
+    this._setVolume( this.volume );
     this._playerInstance.exitFullscreen();
     this._removeLoadingSpinner();
   }
@@ -227,6 +238,32 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
 
   _filesChanged() {
     this._play();
+  }
+
+  _muteVideo () {
+    if ( !this._playerInstance ) {
+      return;
+    }
+
+    this._playerInstance.volume( 0 );
+    this._playerInstance.muted ( true );
+  }
+
+  _setVolume( volume ) {
+    if ( !this._playerInstance ) {
+      return;
+    }
+
+    const normalizedVolume = clampNumber( volume, 0, 100 );
+
+    // TODO: Check for valid display id
+
+    if ( normalizedVolume === 0 ) {
+      this._muteVideo();
+    } else {
+      this._playerInstance.volume( normalizedVolume / 100 );
+      this._playerInstance.muted ( false );
+    }
   }
 }
 

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -19,7 +19,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
           height: 100%;
         }
       </style>
-      <rise-video-player files="{{_filesToRenderList}}"></rise-video-player>
+      <rise-video-player files="{{_filesToRenderList}}" volume="[[volume]]"></rise-video-player>
     `;
   }
 
@@ -30,6 +30,10 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
         value: () => {
           return [];
         }
+      },
+      volume: {
+        type: Number,
+        value: () => 0
       }
     }
   }
@@ -53,6 +57,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     this._filesList = [];
     this._filesToRenderList = [];
     this._validFiles = [];
+    this._volume = 0;
   }
 
   _handleStart() {

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -19,7 +19,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
           height: 100%;
         }
       </style>
-      <rise-video-player files="{{_filesToRenderList}}" volume="[[volume]]"></rise-video-player>
+      <rise-video-player id="videoPlayer" files="{{_filesToRenderList}}" volume="[[volume]]"></rise-video-player>
     `;
   }
 
@@ -57,7 +57,6 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     this._filesList = [];
     this._filesToRenderList = [];
     this._validFiles = [];
-    this._volume = 0;
   }
 
   _handleStart() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,3 +23,7 @@ export function getAspectRatio( width, height ) {
 
   return width / divisor + ":" + height / divisor;
 }
+
+export function clampNumber( value, min, max ) {
+  return Math.max( Math.min( value, max ), min ); // Clamp volume to 0-100 range
+}

--- a/test/integration/videojs.html
+++ b/test/integration/videojs.html
@@ -136,7 +136,40 @@
           element._playerInstance.on( "play", onPlay );
         });
       } );
-    </script>
+  
+      suite( "volume", () => {
+        setup (() => {
+          element = fixture("test-block");
+        } );
+
+        test( "player volume should default to 0 and be muted intially", () => {
+          assert.strictEqual( element._playerInstance.volume(), 0 );
+          assert.strictEqual( element._playerInstance.muted(), true );
+        } );
+
+        test( "setting volume should behave as expected", () => {
+          element._setVolume( 100 );
+          assert.strictEqual( element._playerInstance.volume(), 1 );
+          assert.strictEqual( element._playerInstance.muted(), false );
+
+          element._setVolume( 999 );
+          assert.strictEqual( element._playerInstance.volume(), 1 );
+          assert.strictEqual( element._playerInstance.muted(), false );
+
+          element._setVolume( 50 );
+          assert.strictEqual( element._playerInstance.volume(), 0.5 );
+          assert.strictEqual( element._playerInstance.muted(), false );
+
+          element._setVolume( 0 );
+          assert.strictEqual( element._playerInstance.volume(), 0 );
+          assert.strictEqual( element._playerInstance.muted(), true );
+
+          element._setVolume( -25 );
+          assert.strictEqual( element._playerInstance.volume(), 0 );
+          assert.strictEqual( element._playerInstance.muted(), true );
+        } );
+      } );
+  </script>
 
   </body>
 </html>

--- a/test/unit/rise-video-player.html
+++ b/test/unit/rise-video-player.html
@@ -50,7 +50,8 @@
           playlist: sinon.spy(),
           removeChild: sinon.spy(),
           videoHeight: sinon.spy(),
-          videoWidth: sinon.spy()
+          videoWidth: sinon.spy(),
+          volume: sinon.spy()
         };
 
         videojs.playlist.currentItem = sinon.spy();
@@ -193,6 +194,47 @@
             done();
           } );
         });
+      } );
+
+      suite( "volume", () => {
+        test( "volume should default to 0", () => {
+          assert.strictEqual( element.volume, 0 );
+        } );
+
+        test( "player should be muted initially", () => {
+          assert.equal( element._playerInstance.volume.callCount, 1 );
+          assert.deepEqual( element._playerInstance.volume.lastCall.args, [ 0 ] );
+          assert.equal( element._playerInstance.muted.callCount, 1 );
+          assert.deepEqual( element._playerInstance.muted.lastCall.args, [ true ]  );
+        } );
+
+        test( "setVolume should be called when volume changes", () => {
+          sinon.spy( element, "_setVolume" );
+
+          element.volume = 50;
+          
+          assert.deepEqual( element._setVolume.lastCall.args, [ 50 ] );
+
+          sinon.restore();
+        } );
+
+        test( "invalid volume values should be clamped", () => {
+          element.volume = 999;
+
+          assert.equal( element.volume, 100 );
+          assert.deepEqual( element._playerInstance.volume.lastCall.args, [ 1 ] );
+
+          element.volume = -400;
+          assert.equal( element.volume, 0 );
+          assert.deepEqual( element._playerInstance.volume.lastCall.args, [ 0 ] );    
+        } );
+
+        // TODO:
+        // _muteVideo
+        // _setVolume
+        // Should be muted when volume set to <= 0
+        // Should be unmuted when volume set to >= 0
+        // Integration tests for videojs
       } );
     </script>
   </body>

--- a/test/unit/rise-video-player.html
+++ b/test/unit/rise-video-player.html
@@ -229,12 +229,21 @@
           assert.deepEqual( element._playerInstance.volume.lastCall.args, [ 0 ] );    
         } );
 
-        // TODO:
-        // _muteVideo
-        // _setVolume
-        // Should be muted when volume set to <= 0
-        // Should be unmuted when volume set to >= 0
-        // Integration tests for videojs
+        test( "video should be muted when volume is set to 0", () => {
+          element._playerInstance.muted.resetHistory();
+          element._setVolume( 0 );
+          assert.equal( element._playerInstance.muted.callCount, 1 );
+          assert.deepEqual( element._playerInstance.muted.lastCall.args, [ true ]  );
+        } );
+
+        test( "video should be unmuted when muted and volume set to > 0", () => {
+          element._setVolume( 0 );
+          element._playerInstance.muted.resetHistory();
+
+          element._setVolume( 50 );
+          assert.equal( element._playerInstance.muted.callCount, 2 );
+          assert.deepEqual( element._playerInstance.muted.lastCall.args, [ false ]  );
+        } );
       } );
     </script>
   </body>

--- a/test/unit/rise-video.html
+++ b/test/unit/rise-video.html
@@ -44,7 +44,8 @@
           playlist: sinon.spy(),
           removeChild: sinon.spy(),
           videoHeight: sinon.spy(),
-          videoWidth: sinon.spy()
+          videoWidth: sinon.spy(),
+          volume: sinon.spy()
         };
 
         videojs.playlist.currentItem = sinon.spy();
@@ -164,6 +165,18 @@
 
           assert.deepEqual( element.managedFiles, [ { filePath: "foo.mp4", fileUrl: sampleUrl("foo.mp4"), order: 0 }, { filePath: "bar.webm", fileUrl: sampleUrl("bar.webm"), order: 1 } ] );
         });
+      } );
+
+      suite( "volume", () => {
+        test( "volume defaults to 0", () => {
+          assert.strictEqual( element.volume, 0 );
+        } );
+
+        test( "volume updates in video player when changed", () => {
+          element.volume = 75;
+          
+          assert.strictEqual( element.$.videoPlayer.volume, 75 );
+        } );
       } );
     </script>
 

--- a/test/unit/utils.html
+++ b/test/unit/utils.html
@@ -14,7 +14,7 @@
   <body>
 
     <script type="module">
-      import { getAspectRatio, getVideoFileType } from "../../src/utils";
+      import { clampNumber, getAspectRatio, getVideoFileType } from "../../src/utils";
 
       suite( "getVideoFileType", () => {
         test( "should return filetype for supported formats", () => {
@@ -44,6 +44,14 @@
 
         test( "should return 5:4 aspect ratio", () => {
           assert.equal( getAspectRatio( 1280, 1024 ), "5:4" );
+        } );
+      } );
+
+      suite( "clampNumber", () => {
+        test( "should clamp numbers to range", () => {
+          assert.strictEqual( clampNumber( -100, 0, 100 ), 0 );
+          assert.strictEqual( clampNumber( 101, 0, 100 ), 100 );
+          assert.strictEqual( clampNumber( 50, 0, 100 ), 50 );
         } );
       } );
     </script>


### PR DESCRIPTION
## Description
Add volume support to the rise-video component.

## Motivation and Context
Users of the component need to be able to control the volume of videos and know that the volume will be muted by default.

Implemented according to [this section of the component design](https://docs.google.com/document/d/1LG_h_jQX8UlGLHfmZhEch0DCQyeVxmCnnDAUyU0CaoQ/edit#heading=h.wu8l3nc6gh0y)

## How Has This Been Tested?
- Both unit and integration tests have been added for new code
- Changes have been tested on both Electron and Chrome extension players using [this presentation](https://apps.risevision.com/templates/edit/3dfa38f2-7b70-4abe-858e-4cb14f81d139) which uses a test template with a sample video containing audio and a range slider which dynamically adjusts the volume of the video by updating the `volume` attribute of the `rise-video` component

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed.
  - Manual Test: Completed as noted above
  - Automated Test: Completed as noted above
  - Monitoring: Since it's Friday, we'll wait to merge this PR until Monday
  - Rollback: The previous release has been tagged so rollback should be simple
  - Documentation: The documentation has been updated with information about the new `volume` attribute
  - Internal Communication: Support does not need to be notified as the component is not in use 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No release checklist items were skipped.