### PR TITLE
Chore/e2e

### DIFF
--- a/e2e/rise-video.html
+++ b/e2e/rise-video.html
@@ -30,14 +30,6 @@
       }
     </script>
     <style>
-      .wrapper {
-        width: 100%;
-        height: 100%;
-        display: flex;
-        align-content: center;
-        justify-content: center;
-      }
-
       .video-container:first-child {
         width: 300px;
         height: 200px;
@@ -52,20 +44,18 @@
     </style>
   </head>
   <body>
-    <div class="wrapper">
-      <div class="video-container">
-        <rise-video
-          id="rise-video-01"
-          files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-video-demo/Test-Pattern.mp4"]'>
-        </rise-video>
-      </div>
+    <div class="video-container">
+      <rise-video
+        id="rise-video-01"
+        files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-video-demo/Test-Pattern.mp4"]'>
+      </rise-video>
+    </div>
 
-      <div class="video-container">
-        <rise-video
-          id="rise-video-02"
-          files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-video-demo/Test-Pattern.webm"]'>
-        </rise-video>
-      </div>
+    <div class="video-container">
+      <rise-video
+        id="rise-video-02"
+        files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-video-demo/Test-Pattern.webm"]'>
+      </rise-video>
     </div>
 
     <script>

--- a/e2e/rise-video.html
+++ b/e2e/rise-video.html
@@ -44,18 +44,20 @@
     </style>
   </head>
   <body>
-    <div class="video-container">
-      <rise-video
-        id="rise-video-01"
-        files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-video-demo/Test-Pattern.mp4"]'>
-      </rise-video>
-    </div>
+    <div class="videos-container">
+      <div class="video-container">
+        <rise-video
+          id="rise-video-01"
+          files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-video-demo/Test-Pattern.mp4"]'>
+        </rise-video>
+      </div>
 
-    <div class="video-container">
-      <rise-video
-        id="rise-video-02"
-        files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-video-demo/Test-Pattern.webm"]'>
-      </rise-video>
+      <div class="video-container">
+        <rise-video
+          id="rise-video-02"
+          files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-video-demo/Test-Pattern.webm"]'>
+        </rise-video>
+      </div>
     </div>
 
     <script>

--- a/e2e/rise-video.html
+++ b/e2e/rise-video.html
@@ -29,10 +29,44 @@
         }
       }
     </script>
+    <style>
+      .wrapper {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-content: center;
+        justify-content: center;
+      }
+
+      .video-container:first-child {
+        width: 300px;
+        height: 200px;
+        background: #ff00ff;
+      }
+
+      .video-container:last-child {
+        width: 200px;
+        height: 300px;
+        background: #00ff00;
+      }
+    </style>
   </head>
   <body>
-    <rise-video id="rise-video-01">
-    </rise-video>
+    <div class="wrapper">
+      <div class="video-container">
+        <rise-video
+          id="rise-video-01"
+          files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-video-demo/Test-Pattern.mp4"]'>
+        </rise-video>
+      </div>
+
+      <div class="video-container">
+        <rise-video
+          id="rise-video-02"
+          files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-video-demo/Test-Pattern.webm"]'>
+        </rise-video>
+      </div>
+    </div>
 
     <script>
       function configureComponents() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-video",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Web component for playing video files on a Rise Vision Template page",
   "scripts": {
     "prebuild": "eslint .",


### PR DESCRIPTION
## Description
Add E2E test page.

## Motivation and Context
The `rise-video` component needs E2E to validate consistent behaviour over time.

Expected screenshots uploaded for both [beta](https://storage.googleapis.com/risevision-display-screenshots/M978YFZS8TQX.jpg) and [stable](https://storage.googleapis.com/risevision-display-screenshots/HZ7RT6SS322G.jpg) players.

## How Has This Been Tested?
Changes have been pushed to an `e2e/xxx` branch and the CircleCI build successfully completed. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manual Test: Completed as noted above
  - Automated Test: Completed as noted above
  - Monitoring: No monitoring should be necessary for this change
  - Rollback: The previous release has been tagged so rollback should be simple
  - Documentation: No documentation changes required
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- No release checklist items were skipped