### PR TITLE
Fix handling of empty files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-video",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Web component for playing video files on a Rise Vision Template page",
   "scripts": {
     "prebuild": "eslint .",

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -189,7 +189,6 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
   }
 
   _initPlaylist() {
-
     let playlist = [],
         playlistItem,
         sources,
@@ -213,6 +212,10 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
     }
 
     this._playerInstance.playlist( playlist );
+
+    if ( playlist.length === 0) {
+      this._playerInstance.reset();
+    }
   }
 
   _initPlayer() {
@@ -232,7 +235,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
     }
     
     // set a new source
-    if ( this.files && this.files.length && this.files.length > 0 ) {
+    if ( this.files ) {
       this._initPlaylist();
     }
 
@@ -261,6 +264,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
   }
 
   _filesChanged() {
+    console.log("_filesChanged", this.files, this);
     this._play();
   }
 

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -171,6 +171,12 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
   _onPlay() {
     // reset count since this event is evidence of successful play
     this._decodeRetryCount = 0;
+    
+    // playlist has been cleared since we started trying to play a video,
+    // so we need to reset the player
+    if ( !this.files.length ) {
+      this._playerInstance.reset();
+    }
   }
 
   _onLoadedMetaData() {
@@ -264,7 +270,6 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
   }
 
   _filesChanged() {
-    console.log("_filesChanged", this.files, this);
     this._play();
   }
 

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -219,6 +219,8 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
 
     this._playerInstance.playlist( playlist );
 
+    // simply setting an empty playlist will not cause the player from playing
+    // the current video, so we need to reset the player.
     if ( playlist.length === 0) {
       this._playerInstance.reset();
     }

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -103,6 +103,8 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     const isPreview = this._isPreview;
     let filesList;
 
+    console.log("_start", this.id, "files:", this.files, "metadata:", this.metadata); // eslint-disable-line
+
     this.$.previewPlaceholder.style.display = isPreview ? "block" : "";
 
     if ( this._isPreview ) {
@@ -112,20 +114,28 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     if ( this._hasMetadata() ) {
       filesList = this._getFilesFromMetadata();
     } else {
-      filesList = this.files.split( "|" );
+      filesList = this._getDefaultFiles();
     }
       
     const { validFiles } = this.validateFiles( filesList, VALID_FILE_TYPES );
 
+    console.log("filesList", this.id, filesList, this.files, this.metadata, validFiles); // eslint-disable-line
+
+    this.stopWatch();
+
     if ( validFiles && validFiles.length > 0 ) {
       this._validFiles = validFiles;
-      this.stopWatch();
+      console.log("startWatch", this.id, validFiles); // eslint-disable-line
+
       this.startWatch( validFiles );
+    } else {
+      this._configureShowingVideos();
     }
   }
 
   _configureShowingVideos() {
     this._filesToRenderList = this.managedFiles.slice( 0 );
+    console.log("_configureShowingVideos", this.id, this._filesToRenderList); // eslint-disable-line
   }
 
   watchedFileErrorCallback() {
@@ -135,11 +145,15 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   }
 
   watchedFileAddedCallback() {
+    console.log(this.id, "watchedFileAdded"); // eslint-disable-line
+
     this._configureShowingVideos();
   }
 
   watchedFileDeletedCallback( details ) {
     const { filePath } = details;
+    
+    console.log(this.id, "watchedFileDeleted"); // eslint-disable-line
 
     if ( this._filesToRenderList.length === 1 && this._filePathIsRendered( filePath) ) {
       this._filesToRenderList = [];
@@ -153,7 +167,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   }
 
   _reset() {
-    const filesToLog = !this.metadata ? this.files : this._getFilesFromMetadata();
+    const filesToLog = !this._hasMetadata() ? this.files : this._getFilesFromMetadata();
     
     this.log( RiseVideo.LOG_TYPE_INFO, RiseVideo.EVENT_VIDEO_RESET, { files: filesToLog });
     this._start();
@@ -165,8 +179,14 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     });
   }
 
+  _getDefaultFiles() {
+    return this.files.split( "|" )
+      .filter( f => f.trim().length > 0 );
+  }
+
    _hasMetadata() {
-    return !!this.metadata && this.metadata.length > 0;
+    console.log("_hasMetadata", this.id, !!this.metadata, this.metadata); // eslint-disable-line
+    return !!this.metadata;
   }
 
   _childLog( e ) {

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -103,8 +103,6 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     const isPreview = this._isPreview;
     let filesList;
 
-    console.log("_start", this.id, "files:", this.files, "metadata:", this.metadata); // eslint-disable-line
-
     this.$.previewPlaceholder.style.display = isPreview ? "block" : "";
 
     if ( this._isPreview ) {
@@ -119,13 +117,10 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
       
     const { validFiles } = this.validateFiles( filesList, VALID_FILE_TYPES );
 
-    console.log("filesList", this.id, filesList, this.files, this.metadata, validFiles); // eslint-disable-line
-
     this.stopWatch();
 
     if ( validFiles && validFiles.length > 0 ) {
       this._validFiles = validFiles;
-      console.log("startWatch", this.id, validFiles); // eslint-disable-line
 
       this.startWatch( validFiles );
     } else {
@@ -135,7 +130,6 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
 
   _configureShowingVideos() {
     this._filesToRenderList = this.managedFiles.slice( 0 );
-    console.log("_configureShowingVideos", this.id, this._filesToRenderList); // eslint-disable-line
   }
 
   watchedFileErrorCallback() {
@@ -145,15 +139,11 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   }
 
   watchedFileAddedCallback() {
-    console.log(this.id, "watchedFileAdded"); // eslint-disable-line
-
     this._configureShowingVideos();
   }
 
   watchedFileDeletedCallback( details ) {
     const { filePath } = details;
-    
-    console.log(this.id, "watchedFileDeleted"); // eslint-disable-line
 
     if ( this._filesToRenderList.length === 1 && this._filePathIsRendered( filePath) ) {
       this._filesToRenderList = [];
@@ -185,7 +175,6 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   }
 
    _hasMetadata() {
-    console.log("_hasMetadata", this.id, !!this.metadata, this.metadata); // eslint-disable-line
     return !!this.metadata;
   }
 

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -171,7 +171,8 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
 
   _getDefaultFiles() {
     return this.files.split( "|" )
-      .filter( f => f.trim().length > 0 );
+      .map( f => f.trim() )
+      .filter( f => f.length > 0 );
   }
 
    _hasMetadata() {

--- a/test/unit/rise-video-player.html
+++ b/test/unit/rise-video-player.html
@@ -50,6 +50,7 @@
           play: sinon.spy( sinon.stub().resolves() ),
           playlist: playlist,
           removeChild: sinon.spy(),
+          reset: sinon.spy(),
           videoHeight: sinon.spy( sinon.stub().returns( 720 ) ),
           videoWidth: sinon.spy( sinon.stub().returns( 1280 ) ),
           volume: sinon.spy()

--- a/test/unit/rise-video-player.html
+++ b/test/unit/rise-video-player.html
@@ -157,6 +157,14 @@
 
           assert.equal( element._decodeRetryCount, 0 );
         } );
+
+        test( "player should be reset when there are no files", () => {
+          element.files = [];
+          element._playerInstance.reset.resetHistory();
+          element._play();
+
+          assert.equal( element._playerInstance.reset.callCount, 1 );
+        } );
       } );
 
       suite( "_initPlaylist", () => {
@@ -165,10 +173,29 @@
             { sources: [ { src: sampleUrl( FILES[0]), type: sampleType( FILES[0] ) } ] },
             { sources: [ { src: sampleUrl( FILES[1]), type: sampleType( FILES[1] ) } ] }
           ];
-          
+
+          element._playerInstance.playlist.resetHistory();
           element._initPlaylist();
 
           assert.deepEqual( element._playerInstance.playlist.args[0][0], expected );
+        } );
+
+        test( "should be called when initializing player, even if files is empty", () => {
+          element.files = [];
+          sinon.spy( element, "_initPlaylist" );
+          element._play();
+
+          assert.equal( element._initPlaylist.callCount, 1 );
+
+          element._initPlaylist.restore();
+        } );
+
+        test( "player should be reset when there are no files", () => {
+          element.files = [];
+          element._playerInstance.reset.resetHistory();
+          element._initPlaylist();
+
+          assert.equal( element._playerInstance.reset.callCount, 1 );
         } );
       } );
 

--- a/test/unit/rise-video.html
+++ b/test/unit/rise-video.html
@@ -43,6 +43,7 @@
           play: sinon.spy( sinon.stub().resolves() ),
           playlist: sinon.spy(),
           removeChild: sinon.spy(),
+          reset: sinon.spy(),
           videoHeight: sinon.spy(),
           videoWidth: sinon.spy(),
           volume: sinon.spy()

--- a/test/unit/rise-video.html
+++ b/test/unit/rise-video.html
@@ -192,6 +192,14 @@
 
           assert.deepEqual( element.managedFiles, [ { filePath: "foo.mp4", fileUrl: sampleUrl("foo.mp4"), order: 0 }, { filePath: "bar.webm", fileUrl: sampleUrl("bar.webm"), order: 1 } ] );
         });
+
+        test( "_filesToRenderList is updated correctly when metadata has no files", () => {
+          assert.strictEqual( element._filesToRenderList.length, 2);
+
+          element.metadata = [];
+
+          assert.strictEqual( element._filesToRenderList.length, 0);
+        } );
       } );
 
       suite( "volume", () => {
@@ -246,7 +254,45 @@
           assert.equal( style.display, "block" );
         } );
       } );
-    </script>
+
+      suite( "get default files", () => {
+        test( "_getDefaultFiles should return the correct files", () => {
+          element.files = "foo.mp4";
+
+          assert.deepEqual( element._getDefaultFiles(), ["foo.mp4"] );
+
+          element.files = "foo.mp4|bar.mp4";
+
+          assert.deepEqual( element._getDefaultFiles(), ["foo.mp4", "bar.mp4"] );
+        } );
+
+        test( "_getDefaultFiles should handle empty strings correctly", () => {
+          element.files = "";
+
+          assert.strictEqual( element._getDefaultFiles().length, 0 );
+        } );
+
+        test( "_getDefaultFiles should handle extra whitespace correctly", () => {
+          element.files = "   foo.mp4 |  bar.mp4       ";
+
+          assert.deepEqual( element._getDefaultFiles(), ["foo.mp4", "bar.mp4"] );
+        } );
+      })
+
+      suite( "get metadata", () => {
+        test( "should handle no metadata", () => {
+          element.metadata = null;
+
+          assert.strictEqual( element._getFilesFromMetadata().length, 0 );
+        } );
+
+        test( "should return files correctly", () => {
+          element.metadata = [{ file: "foo.mp4" }, { file: "bar.webm" }];
+
+          assert.deepEqual( element._getFilesFromMetadata(), [ "foo.mp4", "bar.webm" ] );
+        } );
+      } );
+</script>
 
   </body>
 </html>


### PR DESCRIPTION
## Description

Fix issues causing incorrect behavior when the component receives empty metadata from the template editor.

## Motivation and Context

Work related to [this Trello card](https://trello.com/c/JYvoFVTm).

During QA testing two issues were noticed:

1) When a `rise-video` component with no default files first receives some files via the metadata attribute and then receives a later update with no files, it was continuing to play the previous files, not reverting to a blank state as desired.
2) When a `rise-video` component with some default files receives a metadata attribute with no files (because they've been removed in the editor), it was reverting to playing the default files, vs. reverting to a blank state as desired.

Solutions:

1) `_filesToRenderList`, which is passed as a property to `rise-video-player`, was not being correctly updated in this case and so a number of changes to `rise-video.js` were made to make sure that the list is updated correctly
2) Even with these fixes in places, although the player instance playlist was being correctly updated (to an empty array), I noticed that the videos were still playing. After some research / experimentation I realized that it's necessary to call `_playerInstance.reset()` to correctly stop video playback in this case, and `reset()` calls were inserted in two places (both immediately when the playlist is updated, and in the `_onPlay` callback, in case of a race condition with a previous playback attempt).

## How Has This Been Tested?

Unit tests were added to cover all changes, and existing tests all run to ensure they still passed.

Changes have been pushed to GCS [here](https://widgets.risevision.com/staging/components/rise-video/2019.08.09.12.42/rise-video.js) and a modified version of the `example-video-component` template which loads this javascript has been pushed to `beta` and `stable`.

*Note: We should revert the modified `example-video-component` after this is merged*

Changes can be tested in apps environment by:

- creating a new presentation based on `example-video-component`
- assigning it to a schedule
- ensuring that the `No Files` component is blank by default in the player
- adding videos to the `No Files` video, and ensuring that they play as expected
- removing those videos and ensuring that the `No Files` component reverts to a blank state in the player
- ensuring that the `Fullscreen` component plays the default videos as expected in the player
- removing the default videos in the editor and ensuring that the `Fullscreen` reverts to a blank state in the player

## Release Plan:

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manual Test: Completed as noted above
  - Automated Test: Completed as noted above
  - Monitoring: Changes won't be merged until Monday and will be tested in Production after deployment.
  - Rollback: Revert to the previous version (v1.0.8)
  - Documentation: No documentation updates required
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?

No release checklist items were skipped.