### PR TITLE
Add PUD

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-video",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Web component for playing video files on a Rise Vision Template page",
   "scripts": {
     "prebuild": "eslint .",

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -51,6 +51,10 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
         type: Number,
         value: 0,
       },
+      playUntilDone: {
+        type: Boolean,
+        value: false
+      },
       // Used during testing to allow player initialization to be
       // deferred until stubs, etc.. are in place
       skipPlayerInit: {
@@ -126,7 +130,10 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
   _onEnded() {
     if ( this._isDone() ) {
       this.dispatchEvent( new CustomEvent( "playlist-done" ) );
-      this._playFirst();
+
+      // if ( !this.playUntilDone ) {
+        this._playFirst();
+      // }
     } else {
       this._playerInstance.playlist.next();
     }

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -181,7 +181,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
     // playlist has been cleared since we started trying to play a video,
     // so we need to reset the player
     if ( !this.files.length ) {
-      this._resetPlayer
+      this._resetPlayer();
     }
   }
 

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -243,7 +243,6 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
   }
 
   _play() {
-    console.log( "play", this.files );
     if (!this._playerInstance) {
       return;
     }

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -106,6 +106,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
 
   _onPlayerInstanceReady() {
     this._configureHandlers();
+    this._setVolume( this.volume );
     this._play();
   }
 
@@ -237,7 +238,6 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
       fluid: false,
     }, this._onPlayerInstanceReady );
 
-    this._setVolume( this.volume );
     this._playerInstance.exitFullscreen();
     this._removeLoadingSpinner();
   }

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -123,11 +123,16 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
   }
 
   _onEnded() {
-    if ( this._playerInstance.playlist.currentItem() >= ( this._playerInstance.playlist().length - 1 ) ) {
+    if ( this._isDone() ) {
+      this.dispatchEvent( new CustomEvent( "playlist-done" ) );
       this._playFirst();
     } else {
       this._playerInstance.playlist.next();
     }
+  }
+
+  _isDone() {
+    return this._playerInstance.playlist.currentItem() >= ( this._playerInstance.playlist().length - 1 );
   }
 
   _onError() {
@@ -175,7 +180,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
     // playlist has been cleared since we started trying to play a video,
     // so we need to reset the player
     if ( !this.files.length ) {
-      this._playerInstance.reset();
+      this._resetPlayer
     }
   }
 
@@ -219,10 +224,10 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
 
     this._playerInstance.playlist( playlist );
 
-    // simply setting an empty playlist will not cause the player from playing
+    // simply setting an empty playlist will not stop the player from playing
     // the current video, so we need to reset the player.
     if ( playlist.length === 0) {
-      this._playerInstance.reset();
+      this._resetPlayer();
     }
   }
 
@@ -238,6 +243,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
   }
 
   _play() {
+    console.log( "play", this.files );
     if (!this._playerInstance) {
       return;
     }
@@ -303,6 +309,11 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
 
   _log( type, event, details = null, additionalFields ) {
     this.dispatchEvent( new CustomEvent( "log", { detail: { type, event, details, additionalFields } } ) );
+  }
+
+  _resetPlayer() {
+    this._playerInstance.reset();
+    this._setVolume( this.volume );
   }
 }
 

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -136,8 +136,6 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     this._clearFirstDownloadTimer();
     this._clearHandleNoFilesTimer();
 
-    console.log( this.id, "start", validFiles ); //eslint-disable-line
-
     if ( validFiles && validFiles.length > 0 ) {
       this._validFiles = validFiles;
 
@@ -218,7 +216,6 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
 
   _done() {
     if ( this.playUntilDone ) {
-      console.log( this.id, "done" ); // eslint-disable-line
       this._sendDoneEvent( true );
     }
   }
@@ -236,7 +233,6 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   }
 
   _handleNoFilesTimer() {
-    console.log( this.id, "no files" ); // eslint-disable-line
     this._done();
   }
 
@@ -249,17 +245,12 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   _waitForFirstDownload() {
     this._clearFirstDownloadTimer();
 
-    console.log( this.id, "wait for first download" ); //eslint-disable-line
-
     this._firstDownloadTimer = setTimeout( this._handleFirstDownloadTimer, this._maximumTimeForFirstDownload );
   }
 
   _handleFirstDownloadTimer() {
     if ( !this.managedFiles.length ) {
-      console.log( this.id, "first download took too long" ); // eslint-disable-line
       this._done();
-    } else {
-      console.log( this.id, this.managedFiles.length, "files after first download timer" ); // eslint-disable-line
     }
   }
 }

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -221,7 +221,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
 
   _done( reason ) {
     if ( this.playUntilDone ) {
-      console.log( this.id, "played until done", reason );
+      console.log( this.id, `played until done (${reason}` );
       this._sendDoneEvent( true );
     }
   }

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -6,6 +6,8 @@ import { version } from "./rise-video-version.js";
 import {} from "./rise-video-player";
 
 export const VALID_FILE_TYPES = [ "mp4", "webm" ];
+export const MAXIMUM_TIME_FOR_FIRST_DOWNLOAD = 15 * 1000;
+export const NO_FILES_DONE_DELAY = 10 * 1000;
 
 export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseElement ) ) {
   static get template() {
@@ -51,6 +53,10 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
       volume: {
         type: Number,
         value: () => 0
+      },
+      playUntilDone: {
+        type: Boolean,
+        value: () => false
       }
     }
   }
@@ -81,12 +87,15 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     this._initialStart = true;
     this._filesToRenderList = [];
     this._validFiles = [];
+    this._noFilesDoneTimer = null
+    this._firstDownloadTimer = null;
   }
 
   ready() {
     super.ready();
 
     this.$.videoPlayer.addEventListener( "log", this._childLog.bind(this) );
+    this.$.videoPlayer.addEventListener( "playlist-done", this._done.bind(this) );
   }
 
   _handleStart() {
@@ -118,12 +127,21 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     const { validFiles } = this.validateFiles( filesList, VALID_FILE_TYPES );
 
     this.stopWatch();
+    this._clearFirstDownloadTimer();
+    this._clearHandleNoFilesTimer();
+
+    console.log( this.id, "start", validFiles ); //eslint-disable-line
 
     if ( validFiles && validFiles.length > 0 ) {
       this._validFiles = validFiles;
 
       this.startWatch( validFiles );
+
+      if ( !this.managedFiles.length ) {
+        this._waitForFirstDownload();
+      }
     } else {
+      this._handleNoFiles();
       this._configureShowingVideos();
     }
   }
@@ -140,6 +158,8 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
 
   watchedFileAddedCallback() {
     this._configureShowingVideos();
+    this._clearHandleNoFilesTimer();
+    this._clearFirstDownloadTimer();
   }
 
   watchedFileDeletedCallback( details ) {
@@ -159,6 +179,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   _reset() {
     const filesToLog = !this._hasMetadata() ? this.files : this._getFilesFromMetadata();
     
+    console.log( this.id, "reset" ); //eslint-disable-line
     this.log( RiseVideo.LOG_TYPE_INFO, RiseVideo.EVENT_VIDEO_RESET, { files: filesToLog });
     this._start();
   }
@@ -187,6 +208,49 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
 
   get _isPreview() {
     return RisePlayerConfiguration.isPreview();
+  }
+
+  _done() {
+    if ( this.playUntilDone ) {
+      console.log( this.id, "done" ); // eslint-disable-line
+      super._sendDoneEvent( true );
+    }
+  }
+
+  _clearHandleNoFilesTimer() {
+    if ( this._noFilesDoneTimer ) {
+      clearTimeout( this._noFilesDoneTimer );
+    }
+  }
+
+  _handleNoFiles() {
+    this._clearHandleNoFilesTimer();
+
+    this._noFilesDoneTimer = setTimeout( () => {
+      console.log( this.id, "no files" ); // eslint-disable-line
+      this._done();
+    }, NO_FILES_DONE_DELAY );
+  }
+
+  _clearFirstDownloadTimer() {
+    if ( this._firstDownloadTimer ) {
+      clearTimeout( this._firstDownloadTimer );
+    }
+  }
+
+  _waitForFirstDownload() {
+    this._clearFirstDownloadTimer();
+
+    console.log( this.id, "wait for first download" ); //eslint-disable-line
+
+    this._firstDownloadTimer = setTimeout( () => {
+      if ( !this.managedFiles.length ) {
+        console.log( this.id, "first download took took too long" ); // eslint-disable-line
+        this._done();
+      } else {
+        console.log( this.id, this.managedFiles.length, "files after first download timer" ); // eslint-disable-line
+      }
+    }, MAXIMUM_TIME_FOR_FIRST_DOWNLOAD );
   }
 }
 

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -213,7 +213,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   _done() {
     if ( this.playUntilDone ) {
       console.log( this.id, "done" ); // eslint-disable-line
-      super._sendDoneEvent( true );
+      this._sendDoneEvent( true );
     }
   }
 
@@ -226,10 +226,12 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   _handleNoFiles() {
     this._clearHandleNoFilesTimer();
 
-    this._noFilesDoneTimer = setTimeout( () => {
-      console.log( this.id, "no files" ); // eslint-disable-line
-      this._done();
-    }, NO_FILES_DONE_DELAY );
+    this._noFilesDoneTimer = setTimeout( this._handleNoFilesTimer, NO_FILES_DONE_DELAY );
+  }
+
+  _handleNoFilesTimer() {
+    console.log( this.id, "no files" ); // eslint-disable-line
+    this._done();
   }
 
   _clearFirstDownloadTimer() {
@@ -243,14 +245,16 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
 
     console.log( this.id, "wait for first download" ); //eslint-disable-line
 
-    this._firstDownloadTimer = setTimeout( () => {
-      if ( !this.managedFiles.length ) {
-        console.log( this.id, "first download took took too long" ); // eslint-disable-line
-        this._done();
-      } else {
-        console.log( this.id, this.managedFiles.length, "files after first download timer" ); // eslint-disable-line
-      }
-    }, MAXIMUM_TIME_FOR_FIRST_DOWNLOAD );
+    this._firstDownloadTimer = setTimeout( this._handleFirstDownloadTimer, MAXIMUM_TIME_FOR_FIRST_DOWNLOAD );
+  }
+
+  _handleFirstDownloadTimer() {
+    if ( !this.managedFiles.length ) {
+      console.log( this.id, "first download took took too long" ); // eslint-disable-line
+      this._done();
+    } else {
+      console.log( this.id, this.managedFiles.length, "files after first download timer" ); // eslint-disable-line
+    }
   }
 }
 

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console, one-var */
+
 import { html } from "@polymer/polymer";
 import { RiseElement } from "rise-common-component/src/rise-element.js";
 import { WatchFilesMixin } from "rise-common-component/src/watch-files-mixin";
@@ -95,13 +97,14 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     // Preserve bindings to this in external callbacks
     this._handleFirstDownloadTimer = this._handleFirstDownloadTimer.bind(this);
     this._handleNoFilesTimer = this._handleNoFilesTimer.bind(this);
+    this._done = this._done.bind(this);
   }
 
   ready() {
     super.ready();
 
     this.$.videoPlayer.addEventListener( "log", this._childLog.bind(this) );
-    this.$.videoPlayer.addEventListener( "playlist-done", this._done.bind(this) );
+    this.$.videoPlayer.addEventListener( "playlist-done", () => this._done( "playlist done" ) );
   }
 
   _handleStart() {
@@ -216,8 +219,9 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     return RisePlayerConfiguration.isPreview();
   }
 
-  _done() {
+  _done( reason ) {
     if ( this.playUntilDone ) {
+      console.log( this.id, "played until done", reason );
       this._sendDoneEvent( true );
     }
   }
@@ -235,7 +239,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   }
 
   _handleNoFilesTimer() {
-    this._done();
+    this._done( "no files" );
   }
 
   _clearFirstDownloadTimer() {
@@ -252,7 +256,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
 
   _handleFirstDownloadTimer() {
     if ( !this.managedFiles.length ) {
-      this._done();
+      this._done( "first download timeout" );
     }
   }
 }

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -89,6 +89,8 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     this._validFiles = [];
     this._noFilesDoneTimer = null
     this._firstDownloadTimer = null;
+    this._maximumTimeForFirstDownload = MAXIMUM_TIME_FOR_FIRST_DOWNLOAD;
+    this._noFilesDoneDelay = NO_FILES_DONE_DELAY;
 
     // Preserve bindings to this in external callbacks
     this._handleFirstDownloadTimer = this._handleFirstDownloadTimer.bind(this);
@@ -230,7 +232,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   _handleNoFiles() {
     this._clearHandleNoFilesTimer();
 
-    this._noFilesDoneTimer = setTimeout( this._handleNoFilesTimer, NO_FILES_DONE_DELAY );
+    this._noFilesDoneTimer = setTimeout( this._handleNoFilesTimer, this._noFilesDoneDelay );
   }
 
   _handleNoFilesTimer() {
@@ -249,7 +251,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
 
     console.log( this.id, "wait for first download" ); //eslint-disable-line
 
-    this._firstDownloadTimer = setTimeout( this._handleFirstDownloadTimer, MAXIMUM_TIME_FOR_FIRST_DOWNLOAD );
+    this._firstDownloadTimer = setTimeout( this._handleFirstDownloadTimer, this._maximumTimeForFirstDownload );
   }
 
   _handleFirstDownloadTimer() {

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -114,18 +114,14 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   }
 
   _stopPresentation() {
-    console.log( this.id, "_stopPresentation" );
     this._stop();
   }
 
   _startPresentation() {
-    console.log( this.id, "_startPresentation" );
     this._reset();
   }
 
   _handleStart() {
-    console.log( this.id, "_handleStart" );
-
     if ( this._initialStart ) {
       this._initialStart = false;
 
@@ -138,8 +134,6 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   _start() {
     const isPreview = this._isPreview;
     let filesList;
-
-    console.log( this.id, "start" );
 
     this.$.previewPlaceholder.style.display = isPreview ? "block" : "";
 
@@ -175,8 +169,6 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   }
 
   _stop() {
-    console.log( this.id, "_stop" );
-    
     this._validFiles = [];
     this._filesToRenderList = [];
     this.stopWatch();
@@ -223,7 +215,6 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
       this.log( RiseVideo.LOG_TYPE_INFO, RiseVideo.EVENT_VIDEO_RESET, { files: filesToLog });
     }
 
-    console.log( this.id, "_reset" );
     this._start();
   }
 
@@ -253,10 +244,9 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     return RisePlayerConfiguration.isPreview();
   }
 
-  _done( reason ) {
+  _done() {
     if ( this.playUntilDone ) {
-      console.log( this.id, `played until done (${reason})` );
-      // this._stop();
+      this._stop();
       this._sendDoneEvent( true );
     }
   }

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -103,6 +103,9 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   ready() {
     super.ready();
 
+    this.addEventListener( "rise-presentation-play", () => this._reset() );
+    this.addEventListener( "rise-presentation-stop", () => this._stop() );
+    
     this.$.videoPlayer.addEventListener( "log", this._childLog.bind(this) );
     this.$.videoPlayer.addEventListener( "playlist-done", () => this._done( "playlist done" ) );
   }
@@ -152,6 +155,14 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
       this._handleNoFiles();
       this._configureShowingVideos();
     }
+  }
+
+  _stop() {
+    this._validFiles = [];
+    this._filesToRenderList = [];
+    this.stopWatch();
+    this._clearFirstDownloadTimer();
+    this._clearHandleNoFilesTimer();
   }
 
   _configureShowingVideos() {

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -145,13 +145,16 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
         this._waitForFirstDownload();
       }
     } else {
+      this._validFiles = [];
       this._handleNoFiles();
       this._configureShowingVideos();
     }
   }
 
   _configureShowingVideos() {
-    this._filesToRenderList = this.managedFiles.slice( 0 );
+    this._filesToRenderList = this.managedFiles
+      .slice( 0 )
+      .filter( f => this._validFiles.includes( f.filePath ) );
   }
 
   watchedFileErrorCallback() {
@@ -183,7 +186,6 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   _reset() {
     const filesToLog = !this._hasMetadata() ? this.files : this._getFilesFromMetadata();
     
-    console.log( this.id, "reset" ); //eslint-disable-line
     this.log( RiseVideo.LOG_TYPE_INFO, RiseVideo.EVENT_VIDEO_RESET, { files: filesToLog });
     this._start();
   }

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -89,6 +89,10 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     this._validFiles = [];
     this._noFilesDoneTimer = null
     this._firstDownloadTimer = null;
+
+    // Preserve bindings to this in external callbacks
+    this._handleFirstDownloadTimer = this._handleFirstDownloadTimer.bind(this);
+    this._handleNoFilesTimer = this._handleNoFilesTimer.bind(this);
   }
 
   ready() {
@@ -250,7 +254,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
 
   _handleFirstDownloadTimer() {
     if ( !this.managedFiles.length ) {
-      console.log( this.id, "first download took took too long" ); // eslint-disable-line
+      console.log( this.id, "first download took too long" ); // eslint-disable-line
       this._done();
     } else {
       console.log( this.id, this.managedFiles.length, "files after first download timer" ); // eslint-disable-line

--- a/test/index.html
+++ b/test/index.html
@@ -17,6 +17,7 @@
       "unit/rise-video-player.html",
       "unit/utils.html",
       "integration/dependencies.html",
+      "integration/rise-video.html",
       "integration/videojs.html"
     ]);
   </script>

--- a/test/integration/rise-video.html
+++ b/test/integration/rise-video.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+    <title>rise-video test</title>
+
+    <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../../node_modules/@polymer/test-fixture/test-fixture.js"></script>
+    <script src="../../node_modules/mocha/mocha.js"></script>
+    <script src="../../node_modules/chai/chai.js"></script>
+    <script src="../../node_modules/sinon/pkg/sinon.js"></script>
+    <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
+    <script src="../../node_modules/video.js/dist/video.min.js"></script>
+    <script src="../../node_modules/videojs-playlist/dist/videojs-playlist.min.js"></script>
+
+    <script type="text/javascript">
+      const sampleUrl = path => `videos/${ path }`;
+
+      RisePlayerConfiguration = {
+        isConfigured: () => true,
+        isPreview: () => false,
+        Logger: {
+          info: sinon.spy(),
+          error: sinon.spy(),
+          warning: sinon.spy()
+        },
+        LocalStorage: {
+          watchSingleFile: () => {}
+        }
+      };
+    </script>
+
+    <script type="module" src="../../src/rise-video.js"></script>
+  </head>
+  <body>
+    <test-fixture id="test-block">
+      <template>
+        <rise-video
+          id="rise-video-01"
+          files=""
+          play-until-done>
+        </rise-video-player>
+      </template>
+    </test-fixture>
+
+    <script type="module">
+      let element;
+
+      teardown( () => {
+        if ( element.$.videoPlayer && element.$.videoPlayer._playerInstance ) {
+          element.$.videoPlayer._playerInstance.dispose();
+        }
+      });
+
+      suite( "play until done", () => {
+        setup (() => {
+          element = fixture("test-block");
+          element._maximumTimeForFirstDownload = 500;
+          element._noFilesDoneDelay = 500;
+        } );
+
+        test( "should wait for the correct amount of time when no files are received before emitting report-done", done => {
+          sinon.spy( element, "_sendDoneEvent" );
+
+          element.metadata = [];
+
+          setTimeout( () => {
+            assert.strictEqual( element._sendDoneEvent.callCount, 0 );
+          }, 200 );
+
+          setTimeout( () => {
+            assert.equal( element._sendDoneEvent.callCount, 1 );
+
+            element._sendDoneEvent.restore();
+            done();
+          }, 500 );
+        } );
+
+        test( "should wait for the correct amount of time for first download before emitting report-done", done => {
+          let finished = false;
+
+          sinon.stub( RisePlayerConfiguration.LocalStorage, "watchSingleFile").callsFake( (file, handler) => {
+            setTimeout( () => {
+              if (finished) { return; }
+              handler( { status: "CURRENT", filePath: file, fileUrl: sampleUrl( file ) } );
+            }, 1000 );
+          } );
+
+          sinon.spy( element, "_sendDoneEvent" );
+          element.metadata = [ {file: "test1-0.5s-noaudio.mp4"}, {file: "test2-0.5s-noaudio.mp4"} ];
+
+          setTimeout( () => {
+            assert.equal( element._sendDoneEvent.callCount, 1 );
+
+            finished = true;
+            element._sendDoneEvent.restore();
+            RisePlayerConfiguration.LocalStorage.watchSingleFile.restore();
+            done();
+          }, 500 );
+        } );
+
+        test( "should not emit report-done if at least one file finished in time", done => {
+          let finished = false;
+
+          sinon.stub( RisePlayerConfiguration.LocalStorage, "watchSingleFile").callsFake( (file, handler) => {
+            setTimeout( () => {
+              if (finished) { return; }
+              handler( { status: "CURRENT", filePath: file, fileUrl: sampleUrl( file ) } );
+            }, 250 );
+          } );
+
+          sinon.spy( element, "_sendDoneEvent" );
+          element.metadata = [ {file: "test1-0.5s-noaudio.mp4"}, {file: "test2-0.5s-noaudio.mp4"} ];
+
+          setTimeout( () => {
+            assert.equal( element._sendDoneEvent.callCount, 0 );
+
+            finished = true;
+            element._sendDoneEvent.restore();
+            RisePlayerConfiguration.LocalStorage.watchSingleFile.restore();
+            done();
+          }, 500 );
+        } );
+      } );
+  </script>
+
+  </body>
+</html>

--- a/test/integration/videojs.html
+++ b/test/integration/videojs.html
@@ -167,6 +167,7 @@
         test( "player volume should default to 0 and be muted intially", () => {
           assert.strictEqual( element._playerInstance.volume(), 0 );
           assert.strictEqual( element._playerInstance.muted(), true );
+          // TODO: Fix failing test
         } );
 
         test( "setting volume should behave as expected", () => {
@@ -212,7 +213,7 @@
           } );
         } );
 
-        test( "A video should work in a container with no dimensions",  done => {
+        test( "a video should work in a container with no dimensions",  done => {
           element = fixture("test-block-no-container");
 
           element._initPlayer();
@@ -227,6 +228,20 @@
             assert.isTrue( videoBounds.height > 0 );
 
             done();
+          } );
+        } );
+
+        suite( "play until done", () => {
+          test( "playlist-done event should be received", () => {
+            // TODO;
+          } );
+
+          test( "should wait for the correct amount of time when no files are received before emitting report-done", () => {
+            // TODO
+          } );
+
+          test( "should wait for first download", () => {
+            // TODO
           } );
         } );
       } );

--- a/test/integration/videojs.html
+++ b/test/integration/videojs.html
@@ -239,16 +239,20 @@
             element = fixture("test-block");
           } );
 
-          test( "report-done should be emitted when playlist finishes", () => {
-            // TODO;
-          } );
+          test( "report-done should be emitted when playlist finishes", done => {
+            sinon.spy( element, "dispatchEvent" );
 
-          test( "should wait for the correct amount of time when no files are received before emitting report-done", () => {
-            // TODO
-          } );
+            let count = 0;
+            element._playerInstance.on( "play", () => {
+              count++;
 
-          test( "should wait for the correct amount of time for first download before emitting report-done", () => {
-            // TODO
+              if ( count > element.files.length ) {
+                assert.isOk( element.dispatchEvent.getCalls().some( call => call.args[0].type === "playlist-done" ) );
+                element.dispatchEvent.restore();
+                done();
+              }
+            } );
+
           } );
         } );
       } );

--- a/test/integration/videojs.html
+++ b/test/integration/videojs.html
@@ -164,10 +164,13 @@
           element = fixture("test-block");
         } );
 
-        test( "player volume should default to 0 and be muted intially", () => {
-          assert.strictEqual( element._playerInstance.volume(), 0 );
-          assert.strictEqual( element._playerInstance.muted(), true );
-          // TODO: Fix failing test
+        test( "player volume should default to 0 and be muted intially", done => {
+          element._playerInstance.on( "play", () => {
+            assert.strictEqual( element._playerInstance.volume(), 0 );
+            assert.strictEqual( element._playerInstance.muted(), true );
+
+            done();
+          } );
         } );
 
         test( "setting volume should behave as expected", () => {
@@ -232,7 +235,11 @@
         } );
 
         suite( "play until done", () => {
-          test( "playlist-done event should be received", () => {
+          setup (() => {
+            element = fixture("test-block");
+          } );
+
+          test( "report-done should be emitted when playlist finishes", () => {
             // TODO;
           } );
 
@@ -240,7 +247,7 @@
             // TODO
           } );
 
-          test( "should wait for first download", () => {
+          test( "should wait for the correct amount of time for first download before emitting report-done", () => {
             // TODO
           } );
         } );

--- a/test/unit/rise-video-player.html
+++ b/test/unit/rise-video-player.html
@@ -236,6 +236,8 @@
         } );
 
         test( "player should be muted initially", () => {
+          element._onPlayerInstanceReady();
+
           assert.equal( element._playerInstance.volume.callCount, 1 );
           assert.deepEqual( element._playerInstance.volume.lastCall.args, [ 0 ] );
           assert.equal( element._playerInstance.muted.callCount, 1 );
@@ -343,6 +345,57 @@
           assert.equal( element._log.lastCall.args[ 2 ].errorMessage, "There was an error" );
 
           element._playerInstance.error = oldErrorFunction;
+        } );
+
+        suite( "play until done", () => {
+          let oldPlaylist, oldCurrentItem;
+
+          setup( () => {
+            oldPlaylist = element._playerInstance.playlist;
+            oldCurrentItem = element._playerInstance.currentItem;
+          } );
+
+          teardown( () => {
+            element._playerInstance.playlist = oldPlaylist;
+            element._playerInstance.currentItem = oldCurrentItem;
+          } );
+
+          test( "should determine when playlist is done", () => {
+            element._playerInstance.playlist = sinon.stub().returns( ['a', 'b', 'c', 'd'] );
+            element._playerInstance.playlist.currentItem = sinon.stub().returns( 2 );
+            
+            assert.equal( element._isDone(), false );
+
+            element._playerInstance.playlist.currentItem.returns( 3 );
+
+            assert.equal( element._isDone(), true );
+          } );
+
+          test( "should dispatch playlist-done event when end of playlist is reached", () => {
+            sinon.spy( element, "dispatchEvent" );
+
+            element._playerInstance.playlist = sinon.stub().returns( ['a', 'b', 'c'] );
+            element._playerInstance.playlist.currentItem = sinon.stub().returns( 2 );
+            element._onEnded();
+
+            assert.equal( element.dispatchEvent.lastCall.args[0].type, "playlist-done" );
+
+            element.dispatchEvent.restore();
+          } );
+
+          test( "should not dispatch playlist-done event if end of playlist has not been reached", () => {
+            sinon.spy( element, "dispatchEvent" );
+
+            element._playerInstance.playlist = sinon.stub().returns( ['a', 'b', 'c'] );
+            element._playerInstance.playlist.currentItem = sinon.stub().returns( 0 );
+            element._playerInstance.playlist.next = sinon.stub();
+            
+            element._onEnded();
+
+            assert.strictEqual( element.dispatchEvent.callCount, 0 );
+
+            element.dispatchEvent.restore();
+          } );
         } );
       } );
     </script>

--- a/test/unit/rise-video.html
+++ b/test/unit/rise-video.html
@@ -65,6 +65,16 @@
       <template>
         <rise-video
           id="rise-video-01"
+          files="test1.mp4|test2.png|test3.webm"
+          play-until-done>
+        </rise-video>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="test-block-without-pud">
+      <template>
+        <rise-video
+          id="rise-video-01"
           files="test1.mp4|test2.png|test3.webm">
         </rise-video>
       </template>
@@ -73,11 +83,11 @@
     <script type="module">
       let element;
 
-      setup (() => {
-        element = fixture("test-block");
-      } );
-
       suite( "logging", () => {
+        setup (() => {
+          element = fixture( "test-block" );
+        } );
+
         const componentData = {
           name: "rise-video",
           id: "rise-video-01",
@@ -108,6 +118,10 @@
       } );
 
       suite( "rise-video", () => {
+        setup (() => {
+          element = fixture( "test-block" );
+        } );
+
         test( "component exists", () => {
           assert.isOk( element );
         } );
@@ -119,9 +133,19 @@
 
           assert.isFalse( element._initialStart );
         });
+
+        test( "attributes should be set correctly", () => {
+          assert.equal( element.files, "test1.mp4|test2.png|test3.webm" );
+          assert.strictEqual( element.volume, 0 );
+          assert.strictEqual( element.playUntilDone, true );
+        } );
       });
 
       suite( "valid filenames", () => {
+        setup (() => {
+          element = fixture( "test-block" );
+        } );
+
         test( "invalid files are filtered out", () => {
           element.dispatchEvent( new CustomEvent( "start" ) );
 
@@ -142,6 +166,10 @@
       } );
 
       suite( "watched files", () => {
+        setup (() => {
+          element = fixture( "test-block" );
+        } );
+
         test( "files to render should be populated", () => {
           element.dispatchEvent( new CustomEvent( "start" ) );
 
@@ -203,6 +231,10 @@
       } );
 
       suite( "volume", () => {
+        setup (() => {
+          element = fixture( "test-block" );
+        } );
+
         test( "volume defaults to 0", () => {
           assert.strictEqual( element.volume, 0 );
         } );
@@ -215,6 +247,10 @@
       } );
 
       suite( "non-preview mode", () => {
+        setup (() => {
+          element = fixture( "test-block" );
+        } );
+
         test( "should hide the preview placeholder if not in preview mode", () => {
           const style = window.getComputedStyle( element.$.previewPlaceholder );
 
@@ -228,7 +264,7 @@
         setup( () => {
           oldIsPreview = RisePlayerConfiguration.isPreview;
           RisePlayerConfiguration.isPreview = sinon.spy( sinon.stub().returns( true ) );
-          element = fixture("test-block");
+          element = fixture( "test-block" );
         } );
 
         teardown( () => {
@@ -256,6 +292,10 @@
       } );
 
       suite( "get default files", () => {
+        setup (() => {
+          element = fixture( "test-block" );
+        } );
+
         test( "_getDefaultFiles should return the correct files", () => {
           element.files = "foo.mp4";
 
@@ -280,6 +320,10 @@
       })
 
       suite( "get metadata", () => {
+        setup (() => {
+          element = fixture( "test-block" );
+        } );
+
         test( "should handle no metadata", () => {
           element.metadata = null;
 
@@ -292,7 +336,116 @@
           assert.deepEqual( element._getFilesFromMetadata(), [ "foo.mp4", "bar.webm" ] );
         } );
       } );
-</script>
 
+      suite( "play until done", () => {
+        setup( () => {
+          element = fixture( "test-block" );
+        } );
+
+        test( "should not set up files done timer if no files are provided", () => {
+          assert.isNotOk( element._noFilesDoneTimer);
+        } );
+
+        test( "should set up no files done timer if no files are provided", () => {
+          element.metadata = [];
+
+          assert.isOk( element._noFilesDoneTimer);
+        } );
+
+        test( "should emit report-done event if play until done is enabled", () => {
+          sinon.spy( element, "_sendDoneEvent");
+          
+          element._done();
+
+          assert.strictEqual( element._sendDoneEvent.callCount, 1);
+
+          element._sendDoneEvent.restore();
+        } );
+
+        test( "should call _done() when first download timer fires, if no files have been downloaded", () => {
+          sinon.spy( element, '_done' );
+
+          element.managedFiles = [];
+          element._handleFirstDownloadTimer();
+
+          assert.equal( element._done.callCount, 1 );
+
+          element._done.restore();
+        } );
+
+        test( "should not call _done() when first download timer fires, if some files have been downloaded", () => {
+          sinon.spy( element, '_done' );
+
+          element.managedFiles = ["a", "b", "c"];
+          element._handleFirstDownloadTimer();
+
+          assert.equal( element._done.callCount, 0 );
+
+          element._done.restore();
+        } );
+
+
+        test( "should call _done() when no files timer fires", () => {
+          sinon.spy( element, '_done' );
+
+          element._handleNoFilesTimer();
+
+          assert.equal( element._done.callCount, 1 );
+
+          element._done.restore();
+        } );
+      } );
+
+      suite( "play until done disabled", () => {
+        test( "attribute should be set correctly", () => {
+          assert.strictEqual( element.playUntilDone, false );
+        } );
+        
+        setup( () => {
+          element = fixture( "test-block-without-pud" );
+        } );
+
+        test( "should not emit report-done event if play until done is disabled", () => {
+          sinon.spy( element, "_sendDoneEvent");
+          
+          element._done();
+
+          assert.strictEqual( element._sendDoneEvent.callCount, 0);
+
+          element._sendDoneEvent.restore();
+        } );
+      } );
+
+      suite( "play until done with no files downloaded", () => {
+        setup( () => {
+          sinon.stub( RisePlayerConfiguration.LocalStorage, 'watchSingleFile').callsFake( () => {} );
+          element = fixture( "test-block" );
+        } );
+
+        teardown( () => {
+          RisePlayerConfiguration.LocalStorage.watchSingleFile.restore();
+        } );
+
+        test( "should set up first download timer when files aren't already in storage", () => {
+          assert.isOk( element._firstDownloadTimer );
+        } );
+
+        test( "should clear first download timer if a file is received", () => {
+          assert.isOk( element._firstDownloadTimer );
+
+          element.managedFiles = []
+        } );
+      } );
+
+      suite( "play until done with files downloaded", () => {
+        setup( () => {
+          element = fixture( "test-block" );
+        } );
+
+        test( "should set up first download timer when files aren't already in storage", () => {
+          assert.isNotOk( element._firstDownloadTimer );          
+        } );
+      });
+    </script>
   </body>
 </html>

--- a/test/unit/rise-video.html
+++ b/test/unit/rise-video.html
@@ -86,6 +86,7 @@
       suite( "logging", () => {
         setup (() => {
           element = fixture( "test-block" );
+          element.dispatchEvent( new CustomEvent( "start" ) );
         } );
 
         const componentData = {
@@ -95,8 +96,6 @@
         };
 
         test( "should log 'video-start' event with correct params", () => {
-          element.dispatchEvent( new CustomEvent( "start" ) );
-
           assert.deepEqual( RisePlayerConfiguration.Logger.info.lastCall.args[ 0 ], componentData );
           assert.equal( RisePlayerConfiguration.Logger.info.lastCall.args[ 1 ], "video-start" );
           assert.deepEqual( RisePlayerConfiguration.Logger.info.lastCall.args[ 2 ], { files: FILES } );
@@ -144,11 +143,10 @@
       suite( "valid filenames", () => {
         setup (() => {
           element = fixture( "test-block" );
+          element.dispatchEvent( new CustomEvent( "start" ) );
         } );
 
         test( "invalid files are filtered out", () => {
-          element.dispatchEvent( new CustomEvent( "start" ) );
-
           assert.deepEqual( element._validFiles, [ "test1.mp4", "test3.webm" ] );
         } );
 

--- a/test/unit/rise-video.html
+++ b/test/unit/rise-video.html
@@ -230,6 +230,35 @@
         } );
       } );
 
+      suite( "watched file updates", () => {
+        setup( () => {
+          sinon.stub( RisePlayerConfiguration.LocalStorage, 'watchSingleFile').callsFake( (file, handler) => {
+            setTimeout( () => {
+              handler( { status: "CURRENT", filePath: file, fileUrl: sampleUrl( file ) } );
+            }, 100);
+          } );
+
+          element = fixture( "test-block" );
+        } );
+
+        teardown( () => {
+          RisePlayerConfiguration.LocalStorage.watchSingleFile.restore();
+        } );
+
+        test( "_filesToRenderList should not contain watched files which are returned after they're no longer needed", done => {
+          element.metadata = [ {file: "newFile1.mp4"}, {file: "newFile2.mp4"} ];
+
+          setTimeout( () => {
+            assert.equal( element.managedFiles.length, 4 );
+            assert.deepEqual( element._filesToRenderList, [
+              { filePath: "newFile1.mp4", fileUrl: sampleUrl( "newFile1.mp4" ), order: 0 },
+              { filePath: "newFile2.mp4", fileUrl: sampleUrl( "newFile2.mp4" ), order: 1 }
+            ]);
+            done();
+          }, 200 );
+        } );
+      } );
+
       suite( "volume", () => {
         setup (() => {
           element = fixture( "test-block" );


### PR DESCRIPTION
## Description

Add PUD functionality to the `rise-video` component.

## Motivation and Context

Work related to [this Trello card](https://trello.com/c/MZ8ynFMM).

Implement PUD functionality in the `rise-video` component, similar to what was done for `rise-image`.

Each `rise-video` component, when a `play-until-done` attribute is set, should emit a `report-done` event when the playlist reaches its end.

Additionally, if a `rise-video` component receives an empty list of files, it should emit a `report-done` event after 10 seconds.

Finally, if a `rise-video` component receives one of more files, but those files take some time to download, it should emit a `report-done` event after waiting for a maximum of 15 seconds.

During testing of these changes, a small issue was found which caused videos to sometimes play audio even if they should have been muted. A fix for this issue has been included.

## How Has This Been Tested?

Unit and integration tests were added to cover all changes.

Changes have been deployed to GCS [here](https://widgets.risevision.com/staging/components/rise-video/2019.08.13.12.27/rise-video.js), and included in a test schedule [here](https://apps.risevision.com/schedules/details/b05ecec8-0204-4fb0-bac4-67e76e04a996?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f) and can be tested by adding a player to this schedule and verifying that the player cycles through the 6 example presentations as expected:

1) One component with a 5 second video and 2 components with no videos which should wait for the 10 second timeout, taking a total of 10 seconds
2) An example image PUD presentation
3) 3 components each with a 5 second video, taking a total of 5 seconds
4) An example image PUD presentation
5) One component with a 5 second video, one component with a 20 second video and one component with no videos, taking a total of 20 seconds
6) An example image PUD presentation

Notes:

- There are several issues with PUD inside Viewer which will be addressed in a later card. For now, only test in an environment which will reload the page for each presentation in the schedule, such as the Chrome plugin.
- You may need to wait for videos to download successfully before timing match those listed above if video download takes more than the 15 seconds allowed for the first download
- It's possible (but tricky) to test the 15 second first download timeout by creating a presentation with a very large video and / or restricting your bandwidth and then verifying the PUD is triggered after 15 seconds. I've tested this manually and there are integration tests in place, so we may want to come back to this during QA.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manual Test: Completed as noted above
  - Automated Test: Completed as noted above
  - Monitoring: Changes will be manually tested after pushing to Production.
  - Rollback: Revert to the previous release (v1.0.10)
  - Documentation: No documentation updates required as play until done is a feature of all components.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
