### PR TITLE
Feature/handle errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.7",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.9",
     "video.js": "7.6.0",
     "videojs-playlist": "4.3.1"
   },

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -32,7 +32,8 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
           background: transparent !important;
         }
 
-        .vjs-error-display {
+        .vjs-modal-dialog,
+        .vjs-poster {
           display: none !important;
         }
       </style>
@@ -143,8 +144,6 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
   _onError() {
     const error = this._playerInstance.error();
 
-    console.log("error", error);
-
     if ( error && error.code === 3 ) {
       console.log( "DECODE error retry count", this._decodeRetryCount );
       if ( this._decodeRetryCount < this._maxDecodeRetries ) {
@@ -153,7 +152,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
         // delay and then force a play()
         setTimeout( () => {
           console.log( "DECODE error retry play()" );
-          this._play();
+          this._playerInstance.play();
         }, this._decodeRetryDelay );
 
         return;
@@ -177,6 +176,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
       };
 
       this._log( RiseVideoPlayer.LOG_TYPE_ERROR, RiseVideoPlayer.EVENT_PLAYER_ERROR, data );
+      this._onEnded(); // skip to the next video
     }
   }
 

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -31,6 +31,10 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
         .video-js {
           background: transparent !important;
         }
+
+        .vjs-error-display {
+          display: none !important;
+        }
       </style>
       <video id="video" class="video-js"></video>
     `;
@@ -139,6 +143,8 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
   _onError() {
     const error = this._playerInstance.error();
 
+    console.log("error", error);
+
     if ( error && error.code === 3 ) {
       console.log( "DECODE error retry count", this._decodeRetryCount );
       if ( this._decodeRetryCount < this._maxDecodeRetries ) {
@@ -246,7 +252,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
     if (!this._playerInstance) {
       return;
     }
-    
+
     // set a new source
     if ( this.files ) {
       this._initPlaylist();

--- a/test/index.html
+++ b/test/index.html
@@ -18,7 +18,7 @@
       "unit/utils.html",
       "integration/dependencies.html",
       "integration/rise-video.html",
-      "integration/videojs.html"
+      "integration/rise-video-player.html"
     ]);
   </script>
 </body>

--- a/test/integration/rise-video-player.html
+++ b/test/integration/rise-video-player.html
@@ -79,15 +79,6 @@
       </template>
     </test-fixture>
 
-    <test-fixture id="test-block-errors">
-      <template>
-        <rise-video-player
-          id="rise-video-player-errors"
-          files='[{ "filePath": "lowres-96x54-5s-noaudio.mp4", "fileUrl": "./videos/lowres-96x54-5s-noaudio.mp4" }, { "filePath": "test1-0.5s-noaudio.mp4", "fileUrl": "./videos/test1-0.5s-noaudio.mp4" }]'>
-        </rise-video-player>
-      </template>
-    </test-fixture>
-
     <script type="module">
       let element;
 
@@ -266,20 +257,6 @@
             } );
 
           } );
-        } );
-      } );
-
-      suite( "errors", () => {
-        setup (() => {
-          element = fixture("test-block-errors");
-        } );
-
-        test( "should play next video in playlist when an error is encountered", done => {
-          // TODO
-        } );
-
-        test( "should re-try playback the correct number of times when encountering decode errors", () => {
-          // TODO
         } );
       } );
   </script>

--- a/test/integration/rise-video-player.html
+++ b/test/integration/rise-video-player.html
@@ -17,7 +17,7 @@
 
     <script type="text/javascript">
       const sampleUrl = path => `videos/${ path }`;
-      const sampleHref = path => window.location.href.replace( "videojs.html", "videos/" + path );
+      const sampleHref = path => window.location.href.replace( "rise-video-player.html", "videos/" + path );
 
       RisePlayerConfiguration = {
         isConfigured: () => true,
@@ -79,6 +79,15 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="test-block-errors">
+      <template>
+        <rise-video-player
+          id="rise-video-player-errors"
+          files='[{ "filePath": "lowres-96x54-5s-noaudio.mp4", "fileUrl": "./videos/lowres-96x54-5s-noaudio.mp4" }, { "filePath": "test1-0.5s-noaudio.mp4", "fileUrl": "./videos/test1-0.5s-noaudio.mp4" }]'>
+        </rise-video-player>
+      </template>
+    </test-fixture>
+
     <script type="module">
       let element;
 
@@ -97,6 +106,9 @@
           const container = element.root.querySelector( "div.video-js" );
           const allowedSiblings = [ container.querySelector( "video" ), container.querySelector( ".vjs-text-track-display" ) ];
           const siblings = Array.from(container.children);
+
+          siblings.forEach( sibling => sibling.classList.remove( "vjs-hidden" ) ); // force elements to be visible
+
           const disallowedSiblings = siblings.filter(el => !allowedSiblings.includes( el ) && window.getComputedStyle(el).display !== "none" );
 
           assert.equal( disallowedSiblings.length, 0 );
@@ -153,12 +165,12 @@
 
           sinon.spy( element, "_onEnded" );
           element._initPlayer();
-          
+
           element._playerInstance.on( "playlistitem", playlistitemSpy );
           element._playerInstance.on( "play", onPlay );
         });
       } );
-  
+
       suite( "volume", () => {
         setup (() => {
           element = fixture("test-block");
@@ -198,7 +210,7 @@
 
       suite( "responsive", () => {
         setup( () => {} );
-        
+
         test( "A video should fill its container",  done => {
           element = fixture("test-block-16x9").children[0];
 
@@ -220,7 +232,7 @@
           element = fixture("test-block-no-container");
 
           element._initPlayer();
-          
+
           element._playerInstance.on( "playing", () => {
             const videoBounds = element.$.video.getBoundingClientRect();
             const elementBounds = element.getBoundingClientRect();
@@ -254,6 +266,20 @@
             } );
 
           } );
+        } );
+      } );
+
+      suite( "errors", () => {
+        setup (() => {
+          element = fixture("test-block-errors");
+        } );
+
+        test( "should play next video in playlist when an error is encountered", done => {
+          // TODO
+        } );
+
+        test( "should re-try playback the correct number of times when encountering decode errors", () => {
+          // TODO
         } );
       } );
   </script>

--- a/test/unit/rise-video-player.html
+++ b/test/unit/rise-video-player.html
@@ -38,7 +38,7 @@
         }
       };
 
-      let playlist = sinon.spy();
+      let playlist = sinon.spy( sinon.stub().returns( [] ) );
       const videojs = () => {
         const videojs = {
           currentSrc: sinon.spy( sinon.stub().returns( "https://storage.googleapis.com/test1.mp4" ) ),
@@ -130,23 +130,45 @@
       suite( "_onError", () => {
         test( "decode errors result in the correct number of retries", done => {
           const oldErrorFunction = element._playerInstance.error;
+          const oldPlayFunction = element._playerInstance.play;
 
+          sinon.spy( element, "_play" );
           element._decodeRetryDelay = 10;
 
-          element._playerInstance.error = sinon.stub().callsFake(() => ({ code: 3}) );
-          sinon.stub( element, "_play" ).callsFake( () => element._onError() );
+          element._playerInstance.error = sinon.stub().callsFake(() => ( { code: 3}) );
+          element._playerInstance.play = sinon.spy( sinon.stub().callsFake( () => {
+            element._onError();
 
-          element._play();
+            return new Promise( resolve => resolve() );
+          } ) );
 
-          setTimeout( () => {
-            assert.equal( element._play.callCount, element._maxDecodeRetries + 1 );
+          sinon.spy( sinon.stub( element, "_onEnded" ).callsFake( () => {
+            assert.equal( element._playerInstance.play.callCount, element._maxDecodeRetries + 1 );
             assert.equal( element._decodeRetryCount, element._maxDecodeRetries );
 
             element._playerInstance.error = oldErrorFunction;
+            element._playerInstance._play = oldPlayFunction;
             element._play.restore();
+            element._onEnded.restore();
 
             done();
-          }, 500 );
+          } ) );
+
+          element._play();
+        } );
+
+        test( "should play next video in playlist when an error is encountered", () => {
+          const oldErrorFunction = element._playerInstance.error;
+
+          element._playerInstance.error = sinon.stub().callsFake(() => ({ code: 1}) );
+          sinon.spy( element, "_onEnded" );
+
+          element._onError();
+
+          assert.equal( element._onEnded.callCount, 1 );
+
+          element._playerInstance.error = oldErrorFunction;
+          element._onEnded.restore();
         } );
       } );
 


### PR DESCRIPTION
## Description

Ensure that the `rise-video` component handles `MediaError` errors. Also, use latest version of `rise-common-component` in order to get separate `file-rls-error` and `file-insufficient-disk-space-error` events.

## Motivation and Context

Related to [this Trello card](https://trello.com/c/8VrYwJmO).

Most of the functionality had already been ported from `widget-video`, but I made some small tweaks and added some additional tests, as well as manual testing mentioned below.

- Added some styles to hide the `VideoJS` error modal from appearing when an error is triggers, and updated a test to ensure this behavior
- `RiseVideoPlayer._onError` now tries to replay the video triggering the error, rather than restarting the playlist
- `RiseVideoPlayer._onError` now skips to the next video on encountering an error (except for `MEDIA_DECODE` errors, which it tries to resolve)

Additionally, I updated the `rise-common-component` version to make use of the work in `this PR`(https://github.com/Rise-Vision/rise-common-component/pull/17).

## How Has This Been Tested?

Code has been pushed to [GCS here](https://widgets.risevision.com/staging/components/rise-video/2019.08.15.19.30/rise-video.js) and a modified `example-video-component` template which points to this code has been pushed to `stable`.

Automated tests were added / updated.

I made some attempts to produce video files which would reliably trigger different types of errors, and looked into other techniques for purposely causing media playback errors, but wasn't able to make much progress.

To manually test error handling:

- Add an `example-video-component` template, such as [this one](https://apps.risevision.com/templates/edit/b3753cd6-baad-4be1-a8d5-6b5bb9713b9a/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f) to a schedule
- Choose a video component and add more than one video to it, add it to a schedule and view in a player
- Open the developer console in your player
- Manually trigger an error (any code but `3`), ie: `document.querySelector('#video1').$.videoPlayer._playerInstance.error({code: 1})`
- Observe that the player skips to the next video
- Manually trigger a `MEDIA_ERR_DECODE` error, ie: `document.querySelector('#video1').$.videoPlayer._playerInstance.error({code: 3})`
- Observe that you see `DECODE error retry count 0` in the console, followed 1 second later by `DECODE error retry play()`
- Observe that you see no errors visible to the user

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manual Test: Completed as noted above
  - Automated Test: Added as noted above.
  - Monitoring: Changes will be manually tested after pushing to Production. Since this component is not use in Production there's minimal risk to merging on a Friday.
  - Rollback: Revert to the previous release
  - Documentation: No documentation updates required
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?

Since this component is not use in Production there's minimal risk to merging on a Friday.
