### PR TITLE
Feature/uptime

### DIFF
--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -177,6 +177,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
 
       this._log( RiseVideoPlayer.LOG_TYPE_ERROR, RiseVideoPlayer.EVENT_PLAYER_ERROR, data );
       this._onEnded(); // skip to the next video
+      this._setUptime( true );
     }
   }
 

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -182,8 +182,9 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
   }
 
   _onPlay() {
-    // reset count since this event is evidence of successful play
+    // reset count and uptime since this event is evidence of successful play
     this._decodeRetryCount = 0;
+    this._setUptimeError( false );
 
     // playlist has been cleared since we started trying to play a video,
     // so we need to reset the player
@@ -227,6 +228,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
 
     if ( !this._playerInstance.playlist ) {
       this._log( RiseVideoPlayer.LOG_TYPE_ERROR, RiseVideoPlayer.EVENT_PLAYLIST_PLUGIN_LOAD_ERROR, { message: "Playlist plugin did not load" } );
+      this._setUptimeError( true );
       return;
     }
 

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -316,6 +316,10 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
     this.dispatchEvent( new CustomEvent( "log", { detail: { type, event, details, additionalFields } } ) );
   }
 
+  _setUptime( enabled ) {
+    this.dispatchEvent( new CustomEvent( "set-uptime", { detail: { enabled } } ) );
+  }
+
   _resetPlayer() {
     this._playerInstance.reset();
     this._setVolume( this.volume );

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -177,7 +177,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
 
       this._log( RiseVideoPlayer.LOG_TYPE_ERROR, RiseVideoPlayer.EVENT_PLAYER_ERROR, data );
       this._onEnded(); // skip to the next video
-      this._setUptime( true );
+      this._setUptimeError( true );
     }
   }
 
@@ -317,7 +317,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
     this.dispatchEvent( new CustomEvent( "log", { detail: { type, event, details, additionalFields } } ) );
   }
 
-  _setUptime( enabled ) {
+  _setUptimeError( enabled ) { // overrides method in RiseElement
     this.dispatchEvent( new CustomEvent( "set-uptime", { detail: { enabled } } ) );
   }
 

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -114,6 +114,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     this._handleFirstDownloadTimer = this._handleFirstDownloadTimer.bind( this );
     this._handleNoFilesTimer = this._handleNoFilesTimer.bind( this );
     this._childLog = this._childLog.bind( this );
+    this._childSetUptime = this._childSetUptime.bind( this );
     this._done = this._done.bind( this );
     this._startPresentation = this._startPresentation.bind( this );
     this._stopPresentation = this._stopPresentation.bind( this );
@@ -126,6 +127,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     this.addEventListener( "rise-presentation-stop", this._stopPresentation );
 
     this.$.videoPlayer.addEventListener( "log", this._childLog );
+    this.$.videoPlayer.addEventListener( "set-uptime", this._childSetUptime );
     this.$.videoPlayer.addEventListener( "playlist-done", () => this._done( "playlist done" ) );
   }
 
@@ -263,6 +265,12 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     const { type, event, details, additionalFields } = e.detail;
 
     this.log( type, event, details, additionalFields );
+  }
+
+  _childSetUptime( e ) {
+    const { enabled } = e.detail;
+
+    this._setUptimeError ( enabled );
   }
 
   get _isPreview() {

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -173,6 +173,11 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
 
     const { validFiles } = this.validateFiles( filesList, VALID_FILE_TYPES );
 
+    if ( filesList && filesList.length && ( !validFiles || !validFiles.length ) ) {
+      // there are some files, but all formats are invalid
+      this._setUptimeError( true );
+    }
+
     if ( validFiles && validFiles.length > 0 ) {
       this._validFiles = validFiles;
 
@@ -242,6 +247,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
       this.log( RiseVideo.LOG_TYPE_INFO, RiseVideo.EVENT_VIDEO_RESET, { files: filesToLog });
     }
 
+    this._setUptimeError( false );
     this._start();
   }
 

--- a/test/integration/rise-video-player.html
+++ b/test/integration/rise-video-player.html
@@ -62,8 +62,7 @@
         <div id="sizing-container-16x9" style="width: 480px; height: 270px">
           <rise-video-player
             id="rise-video-player-16x9"
-            files='[{ "filePath": "16x9-0.5s-noaudio.mp4", "fileUrl": "./videos/16x9-0.5s-noaudio.mp4" }]'
-            skip-player-init="true">
+            files='[{ "filePath": "16x9-0.5s-noaudio.mp4", "fileUrl": "./videos/16x9-0.5s-noaudio.mp4" }]'>
           </rise-video-player>
         </div>
       </template>
@@ -200,12 +199,11 @@
       } );
 
       suite( "responsive", () => {
-        setup( () => {} );
+        setup( () => {
+          element = fixture("test-block-16x9").children[0];
+        } );
 
         test( "A video should fill its container",  done => {
-          element = fixture("test-block-16x9").children[0];
-
-          element._initPlayer();
           element._playerInstance.on( "playing", () => {
             const containerBounds = element.getBoundingClientRect();
             const videoBounds = element.$.video.getBoundingClientRect();
@@ -236,27 +234,27 @@
             done();
           } );
         } );
+      } );
 
-        suite( "play until done", () => {
-          setup (() => {
-            element = fixture("test-block");
+      suite( "play until done", () => {
+        setup (() => {
+          element = fixture("test-block");
+        } );
+
+        test( "report-done should be emitted when playlist finishes", done => {
+          sinon.spy( element, "dispatchEvent" );
+
+          let count = 0;
+          element._playerInstance.on( "play", () => {
+            count++;
+
+            if ( count > element.files.length ) {
+              assert.isOk( element.dispatchEvent.getCalls().some( call => call.args[0].type === "playlist-done" ) );
+              element.dispatchEvent.restore();
+              done();
+            }
           } );
 
-          test( "report-done should be emitted when playlist finishes", done => {
-            sinon.spy( element, "dispatchEvent" );
-
-            let count = 0;
-            element._playerInstance.on( "play", () => {
-              count++;
-
-              if ( count > element.files.length ) {
-                assert.isOk( element.dispatchEvent.getCalls().some( call => call.args[0].type === "playlist-done" ) );
-                element.dispatchEvent.restore();
-                done();
-              }
-            } );
-
-          } );
         } );
       } );
   </script>

--- a/test/integration/rise-video.html
+++ b/test/integration/rise-video.html
@@ -185,6 +185,38 @@
           } );
         } );
       } );
+
+      suite( "child events", () => {
+        setup (() => {
+          element = fixture("test-block");
+        } );
+
+        test( "should successfully pass logs to parent and then to Logger", () => {
+          element.$.videoPlayer._log( "error", "test-error", { foo: "bar" }, { bar: "baz" } );
+
+          assert.isOk( RisePlayerConfiguration.Logger.error.calledWithExactly(
+            { id: "rise-video-01", name: "rise-video", version: "__VERSION__" },
+            "test-error",
+            { foo: "bar" },
+            { bar: "baz" }
+          ) );
+        } );
+
+        test( "should successfully call _setUptimeError in parent", () => {
+          sinon.spy( element, "_setUptimeError" );
+
+          element.$.videoPlayer._setUptime( true );
+
+          assert.isOk( element._setUptimeError.calledOnceWithExactly( true ) );
+
+          element._setUptimeError.resetHistory();
+          element.$.videoPlayer._setUptime( false );
+
+          assert.isOk( element._setUptimeError.calledOnceWithExactly( false ) );
+
+          element._setUptimeError.restore();
+        } );
+      } );
   </script>
 
   </body>

--- a/test/integration/rise-video.html
+++ b/test/integration/rise-video.html
@@ -205,12 +205,12 @@
         test( "should successfully call _setUptimeError in parent", () => {
           sinon.spy( element, "_setUptimeError" );
 
-          element.$.videoPlayer._setUptime( true );
+          element.$.videoPlayer._setUptimeError( true );
 
           assert.isOk( element._setUptimeError.calledOnceWithExactly( true ) );
 
           element._setUptimeError.resetHistory();
-          element.$.videoPlayer._setUptime( false );
+          element.$.videoPlayer._setUptimeError( false );
 
           assert.isOk( element._setUptimeError.calledOnceWithExactly( false ) );
 

--- a/test/unit/rise-video-player.html
+++ b/test/unit/rise-video-player.html
@@ -420,6 +420,41 @@
           } );
         } );
       } );
+
+      suite( "uptime", () => {
+        setup( () => {
+          sinon.spy( element, "_setUptimeError" );
+        } );
+
+        teardown( () => {
+          element._setUptimeError.restore();
+        } );
+
+        test( "should end uptime when a video error is encountered", () => {
+          const oldErrorFunction = element._playerInstance.error;
+
+          element._playerInstance.error = () => ( { code: 1234, message: undefined } );
+          element._onError();
+
+          assert.isOk( element._setUptimeError.calledOnceWithExactly( true ) );
+
+          element._playerInstance.error = oldErrorFunction;
+        } );
+
+        test( "should end uptime when the playlist plugin can't load", () => {
+          playlist = undefined;
+          element._initPlayer();
+          element._initPlaylist();
+
+          assert.isOk( element._setUptimeError.calledOnceWithExactly( true ) );
+        } );
+
+        test( "should reset uptime when a video plays", () => {
+          element._onPlay();
+
+          assert.isOk( element._setUptimeError.calledOnceWithExactly( false ) );
+        } );
+      } );
     </script>
   </body>
 </html>

--- a/test/unit/rise-video.html
+++ b/test/unit/rise-video.html
@@ -513,6 +513,34 @@
           element._reset.restore();
         } );
       } );
+
+      suite( "uptime", () => {
+        setup( () => {
+          element = fixture( "test-block" );
+          sinon.spy( element, "_setUptimeError" );
+        } );
+
+        teardown( () => {
+          element._setUptimeError.restore();
+        } );
+
+        test( "should end uptime when no valid files are provided", () => {
+          element.metadata = [ { file: "foo.jpg" }, { file: "bar.csv" } ];
+
+          assert.deepEqual( element._setUptimeError.lastCall.args, [ true ] );
+        } );
+
+        test( "should not end uptime when no files are provided", () => {
+          element.metadata = [];
+
+          assert.deepEqual( element._setUptimeError.lastCall.args, [ false ] );
+        } );
+
+        test( "shoud reset uptime when _reset is called", () => {
+          element._reset();
+          assert.isOk( element._setUptimeError.calledOnceWithExactly( false ) );
+        } );
+      } );
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Description

Report component uptime.

## Motivation and Context

Changes related to [this Trello card](https://trello.com/c/xySgeNRW).

Adds reporting of uptime error related events, `true` when an error is encountered and `false` when things are working well.

The following result in an uptime error:

- The playlist plugin failing to load
- A `MediaError` being encountered
- A list of files being provided with no files that have valid extensions

The following result in resetting the uptime error:

- `files` or `metadata` attributes being updated
- receiving a `rise-presentation-start` event
- a video successfully playing and triggering `RiseVideoPlayer._onPlay`

## How Has This Been Tested?

Code has been pushed to GCS [here](https://widgets.risevision.com/staging/components/rise-video/2019.08.16.12.37/rise-video.js) and the `example-video-template` in `stable` has been updated to point to it.

Automated tests have been added to cover the changes.

Has been manually tested by:

- Adding my device to [this schedule](https://apps.risevision.com/schedules/details/b05ecec8-0204-4fb0-bac4-67e76e04a996?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f)
- **Scenario 1:**
  - Leaving the presentation running for at least 5 minutes
  - Validating that all 3 `rise-video` components reported uptime with no errors
- **Scenario 2**
  - Causing an unrecoverable uptime error by running this code in the developer console: `document.querySelector('rise-video').metadata=[{file: "a.jpg"}, {file: "b.csv"}];`
  - Waiting at least 5 minutes
  - Validating that `video1` reported uptime with errors, and `video2` and `video3` reported uptime with no errors
- **Scenario 3**
  - Running this code in the developer console to solve the uptime error: `document.querySelector('rise-video').metadata=[{file: "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-video-demo/Yes-No.webm"}];`
  - Waiting at least 5 minutes
  - Validating that all 3 `rise-video` components reported uptime with no errors

Recent uptime data for the test presentation can by checked with this query:

```
SELECT
  ts,
  responding,
  error,
  component_id
  FROM
  `client-side-events.Component_Uptime_Events.events`
  WHERE
  ts >= TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL -1 HOUR)
  AND component_type = "rise-video"
  AND presentation_id = "b3753cd6-baad-4be1-a8d5-6b5bb9713b9a"
  group by ts, responding, error, component_id order by ts DESC
```

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed.
  - Manual Test: Completed as noted above
  - Automated Test: Completed as noted above
  - Monitoring: Changes will be manually tested after pushing to Production.
  - Rollback: Revert to the previous release
  - Documentation: No documentation updates required
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?

Since this component isn't used in Prodution it should be OK to merge on a Friday.
