### PR TITLE
Set volume on every _play

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-video",
-  "version": "1.0.11",
+  "version": "1.0.13",
   "description": "Web component for playing video files on a Rise Vision Template page",
   "scripts": {
     "prebuild": "eslint .",

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -256,6 +256,8 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
       return;
     }
 
+    this._setVolume( this.volume );
+
     // set a new source
     if ( this.files ) {
       this._initPlaylist();
@@ -325,7 +327,6 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
 
   _resetPlayer() {
     this._playerInstance.reset();
-    this._setVolume( this.volume );
   }
 }
 

--- a/test/unit/rise-video-player.html
+++ b/test/unit/rise-video-player.html
@@ -260,9 +260,7 @@
         test( "player should be muted initially", () => {
           element._onPlayerInstanceReady();
 
-          assert.equal( element._playerInstance.volume.callCount, 1 );
           assert.deepEqual( element._playerInstance.volume.lastCall.args, [ 0 ] );
-          assert.equal( element._playerInstance.muted.callCount, 1 );
           assert.deepEqual( element._playerInstance.muted.lastCall.args, [ true ]  );
         } );
 


### PR DESCRIPTION
## Description

Fix an issue with volume not updating correctly.

## Motivation and Context

Fix an issue found during QA preventing volume from updating correctly when changed in Settings, in some cases.

## How Has This Been Tested?

Changes have been pushed to GCS and an updated `example-video-component` has been pushed to `stable` which points to this code.

Tested by:

Adding a device to [this schedule](https://apps.risevision.com/schedules/details/affc198c-62ad-48df-8e72-bc9e13c3395e?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f), updating the volume of the `Video - Fullscreen` component of [this presentation](https://apps.risevision.com/templates/edit/b5df98d6-b534-4d62-99f1-b899dde2949d/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f) and validating that the volume of the video updates as expected.

Existing automated tests covered this change.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manual Test: Completed as noted above
  - Automated Test: Not needed as noted above.
  - Monitoring: Changes will be manually tested after pushing to Production.
  - Rollback: Revert to the previous commit
  - Documentation: No documentation updates required
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?

No release checklist items were skipped.
