### PR TITLE
Report pud on errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3850,7 +3850,7 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#21caa77f7837c6d19949be7971ee682ecfc3788d",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#cc6f379e1fca220f5708c700bdf67be799903938",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@webcomponents/webcomponentsjs": "2.2.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-video",
-  "version": "1.0.4",
+  "version": "1.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3850,7 +3850,7 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#0360619d00cf3db935e891d89956226d994b7ef3",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#21caa77f7837c6d19949be7971ee682ecfc3788d",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@webcomponents/webcomponentsjs": "2.2.10"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#fix/report-pud-on-rls-error",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.10",
     "video.js": "7.6.0",
     "videojs-playlist": "4.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.9",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#fix/report-pud-on-rls-error",
     "video.js": "7.6.0",
     "videojs-playlist": "4.3.1"
   },

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -128,7 +128,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
 
     this.$.videoPlayer.addEventListener( "log", this._childLog );
     this.$.videoPlayer.addEventListener( "set-uptime", this._childSetUptime );
-    this.$.videoPlayer.addEventListener( "playlist-done", () => this._done( "playlist done" ) );
+    this.$.videoPlayer.addEventListener( "playlist-done", () => this._done() );
   }
 
   _stopPresentation() {
@@ -212,8 +212,10 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   }
 
   watchedFileErrorCallback() {
-    if ( this.managedFiles.length === 0 ) {
-      this._filesToRenderList = [];
+    this._configureShowingVideos();
+
+    if ( !this._filesToRenderList.length ) {
+      this._done();
     }
   }
 
@@ -303,7 +305,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   }
 
   _handleNoFilesTimer() {
-    this._done( "no files" );
+    this._done();
   }
 
   _clearFirstDownloadTimer() {
@@ -321,7 +323,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
 
   _handleFirstDownloadTimer() {
     if ( !this.managedFiles.length ) {
-      this._done( "first download timeout" );
+      this._done();
     }
   }
 }

--- a/test/integration/rise-video.html
+++ b/test/integration/rise-video.html
@@ -134,6 +134,32 @@
             done();
           }, 500 );
         } );
+
+        test( "should call _done if file list includes single file and it does not exist", () => {
+          element.metadata = [ {file: "foo.mp4"} ];
+          sinon.spy( element, "_done" );
+          element._handleSingleFileError( {filePath: "foo.mp4", status: "NOEXIST" });
+
+          assert.isOk( element._done.calledOnce );
+
+          element._done.restore();
+        } );
+
+        test( "should call _done if file list includes two files and neither exists", () => {
+          sinon.stub( RisePlayerConfiguration.LocalStorage, 'watchSingleFile').callsFake( (file, handler) => {
+            handler( { status: "CURRENT", filePath: file, fileUrl: sampleUrl( file ) } );
+          } );
+
+          element.metadata = [ {file: "foo.mp4"}, {file: "bar.mp4"} ];
+          sinon.spy( element, "_done" );
+          element._handleSingleFileError( {filePath: "foo.mp4", status: "NOEXIST" });
+          element._handleSingleFileError( {filePath: "bar.mp4", status: "NOEXIST" });
+
+          assert.isOk( element._done.calledOnce );
+
+          element._done.restore();
+          RisePlayerConfiguration.LocalStorage.watchSingleFile.restore();
+        } );
       } );
 
       suite( "presentation events", () => {


### PR DESCRIPTION
## Description

Fix PUD not being reported when all files had errors.

## Motivation and Context

Work related to [this Trello card](https://trello.com/c/7dNtZgYT). Replicates an [earlier fix to rise-image](https://github.com/Rise-Vision/rise-image/pull/40).

Related changes to `rise-common-component` in [this PR](https://github.com/Rise-Vision/rise-common-component/pull/19).

Note: `rise-common-component` version will be updated before this is merged.

## How Has This Been Tested?

Changes have been pushed to GCS and an updated `example-video-component` has been pushed to `stable` which points to this code.

Tested by:

- Adding your device to [this schedule](https://apps.risevision.com/schedules/details/c1f5f181-7271-4e8c-bfac-7b0cea056a02?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f) which is configured so that `Video - Fullscreen` contains two videos which have been deleted from RLS and will throw a `file-not-found` error, and the other two components contain valid, 5-second long videos.
- Validating that the schedule advances to the next (`rise-image`) presentation after 5 seconds, due to PUD being triggered immediately due to the now handled `file-not-found` errors on `Video - Fullscreen` and after 5 seconds on the other two, vs the previous behavior of  10 seconds, due to the errors not being handled and the component waiting for the `noFilesTimeout` to trigger.

Automated tests were updated to cover this change.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manual Test: Completed as noted above
  - Automated Test: Completed as noted above
  - Monitoring: Changes will be manually tested after pushing to Production.
  - Rollback: Revert to the previous commit
  - Documentation: No documentation updates required
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?

No release checklist items were skipped.
