### PR TITLE
Implement watchdog timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The component may log the following:
 - **_video-reset_** ( info ): The component observed changes to either _files_ or _metadata_ attributes and performs a complete reset to use latest values.
 - **_player-error_** ( error ): An error is received from the VideoJS player.
 - **_playlist-plugin-load-error_** (error): The videojs-player plugin for the VideoJS player failed to load.
+- **_video-stuck_** (info): The video currentTime stopped advancing and could not be recovered.
 
 Additionally, because the component inherits from [WatchFilesMixin](https://github.com/Rise-Vision/rise-common-component/blob/master/src/watch-files-mixin.js) and [ValidFilesMixin](https://github.com/Rise-Vision/rise-common-component/blob/master/src/valid-files-mixin.js) in [rise-common-component](https://github.com/Rise-Vision/rise-common-component), it may log the following:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-video",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Web component for playing video files on a Rise Vision Template page",
   "scripts": {
     "prebuild": "eslint .",

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -151,8 +151,6 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
 
     const currentTime = this._playerInstance.currentTime();
 
-    console.info( "watchdog:", currentTime, this._lastCurrentTime);
-
     if ( currentTime === this._lastCurrentTime ) {
       console.warn( "watchdog: video stuck" );
 
@@ -166,7 +164,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
         console.warn( "watchdog: max unstick attempts exceeded" );
         this._log( RiseVideoPlayer.LOG_TYPE_WARNING, RiseVideoPlayer.EVENT_VIDEO_STUCK, { fileUrl: this._playerInstance.currentSrc() } );
       }
-    } else {
+    } else if ( this._unstickAttempts > 0 ) {
       console.info( "watchdog: reset unstick attempts" );
       // Reset count, since currentTime has changed since we last checked
       this._unstickAttempts = 0;

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -84,6 +84,10 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
     return "playlist-plugin-load-error";
   }
 
+  static get EVENT_VIDEO_STUCK() {
+    return "video-stuck";
+  }
+
   constructor() {
     super();
 
@@ -138,19 +142,19 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
 
       const currentTime = this._playerInstance.currentTime();
 
-      console.log( "watchdog:", currentTime, this._lastCurrentTime);
+      console.info( "watchdog:", currentTime, this._lastCurrentTime);
 
       if ( currentTime === this._lastCurrentTime ) {
-        console.log( "watchdog: video stuck" );
+        console.error( "watchdog: video stuck" );
 
         if ( this._unstickAttempts < this._maxUnstickAttempts ) {
-          console.log( "watchdog: attempting to unstick" );
+          console.info( "watchdog: attempting to unstick" );
           this._playerInstance.play();
           this._unstickAttempts ++;
         } else {
           this._onEnded();
-          console.log( "watchdog: max unstick attempts exceeded" );
-          // TODO: Log error
+          console.error( "watchdog: max unstick attempts exceeded" );
+          this._log( RiseVideoPlayer.LOG_TYPE_WARNING, RiseVideoPlayer.EVENT_VIDEO_STUCK, { fileUrl: this._playerInstance.currentSrc() } );
         }
 
         this._lastCurrentTime = currentTime;
@@ -223,7 +227,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
     this._setUptimeError( false );
 
     // reset watchdog
-    console.log( "watchdog: clear" );
+    console.info( "watchdog: clear" );
     this._unstickAttempts = 0;
     this._lastCurrentTime = null;
 

--- a/test/integration/rise-video-player.html
+++ b/test/integration/rise-video-player.html
@@ -313,19 +313,20 @@
 
           element._playerInstance.on( "playing", () => {
             sinon.spy( element, "_onEnded" );
+            element._lastCurrentTime = 0;
             element._playerInstance.pause();
             sinon.stub(element._playerInstance, "play").resolves();
             element._configureWatchdog();
 
             setTimeout( () => {
-              assert.strictEqual( element._unstickAttempts, 5 );
+              assert.strictEqual( element._unstickAttempts, 0 );
               assert.strictEqual( element._onEnded.callCount, 1 );
               assert.isOk( element._log.calledWithExactly( "warning", "video-stuck", { fileUrl: "./videos/test2-0.5s-noaudio.mp4" } ) );
 
               element._onEnded.restore();
               element._log.restore();
               done();
-            }, 700 );
+            }, 600 );
           } );
         } );
       } );

--- a/test/integration/rise-video-player.html
+++ b/test/integration/rise-video-player.html
@@ -257,6 +257,78 @@
 
         } );
       } );
+
+      suite( "watchdog timer", () => {
+        setup( () => {
+          element = fixture("test-block-deferred");
+        } );
+
+        test( "should configure watchdog", done => {
+          sinon.spy( element, "_configureWatchdog" );
+          element._initPlayer();
+
+          element._playerInstance.on( "play", () => {
+            assert.equal( element._configureWatchdog.callCount, 1 );
+            element._configureWatchdog.restore();
+            done();
+          } );
+        } );
+
+        test( "should run watchdog at correct interval", () => {
+          const clock = sinon.useFakeTimers();
+          sinon.spy( element, "_watchdog" );
+
+          element._watchdogTimerDelay = 10;
+          element._initPlayer();
+          clock.tick( 110 );
+
+          assert.equal( element._watchdog.callCount, 10 );
+
+          element._watchdog.restore();
+          clock.restore();
+        } );
+
+        test( "should try to unstick a video the correct number of times", done => {
+          element._watchdogTimerDelay = 100;
+          element._initPlayer();
+
+          element._playerInstance.on( "playing", () => {
+            element._playerInstance.pause();
+            sinon.stub(element._playerInstance, "play").resolves();
+            element._configureWatchdog();
+
+            setTimeout( () => {
+              assert.equal( element._unstickAttempts, 3 );
+
+              done();
+            }, 400 );
+          } );
+        } );
+
+        test( "should skip to the next video and log an error after the failing to unstick", done => {
+          sinon.spy( element, "_log" );
+          element._watchdogTimerDelay = 100;
+          element._maxUnstickAttempts = 5;
+          element._initPlayer();
+
+          element._playerInstance.on( "playing", () => {
+            sinon.spy( element, "_onEnded" );
+            element._playerInstance.pause();
+            sinon.stub(element._playerInstance, "play").resolves();
+            element._configureWatchdog();
+
+            setTimeout( () => {
+              assert.strictEqual( element._unstickAttempts, 5 );
+              assert.strictEqual( element._onEnded.callCount, 1 );
+              assert.isOk( element._log.calledWithExactly( "warning", "video-stuck", { fileUrl: "./videos/test2-0.5s-noaudio.mp4" } ) );
+
+              element._onEnded.restore();
+              element._log.restore();
+              done();
+            }, 700 );
+          } );
+        } );
+      } );
   </script>
 
   </body>

--- a/test/unit/rise-video-player.html
+++ b/test/unit/rise-video-player.html
@@ -453,6 +453,24 @@
           assert.isOk( element._setUptimeError.calledOnceWithExactly( false ) );
         } );
       } );
+
+      suite( "watchdog timer", () => {
+        test( "should configure watchdog", () => {
+          element._configureWatchdog();
+
+          assert.strictEqual( typeof element._watchdogTimer, "number" );
+        } );
+
+        test( "should reset stuck video detection when video is played successfully", () => {
+          element._unstickAttempts = 999;
+          element._lastCurrentTime = 999;
+
+          element._onPlay();
+
+          assert.strictEqual( element._unstickAttempts, 0 );
+          assert.strictEqual( element._lastCurrentTime, null );
+        } );
+      } );
     </script>
   </body>
 </html>

--- a/test/unit/rise-video-player.html
+++ b/test/unit/rise-video-player.html
@@ -41,12 +41,14 @@
       let playlist = sinon.spy( sinon.stub().returns( [] ) );
       const videojs = () => {
         const videojs = {
+          currentTime: sinon.spy( sinon.stub().returns( 1000 ) ),
           currentSrc: sinon.spy( sinon.stub().returns( "https://storage.googleapis.com/test1.mp4" ) ),
           exitFullscreen: sinon.spy(),
           getChild: sinon.spy(),
           error: sinon.spy(),
           muted: sinon.spy(),
           on: sinon.spy(),
+          pause: sinon.spy(),
           play: sinon.spy( sinon.stub().resolves() ),
           playlist: playlist,
           removeChild: sinon.spy(),
@@ -440,11 +442,15 @@
         } );
 
         test( "should end uptime when the playlist plugin can't load", () => {
+          const oldPlaylist = playlist;
+
           playlist = undefined;
           element._initPlayer();
           element._initPlaylist();
 
           assert.isOk( element._setUptimeError.calledOnceWithExactly( true ) );
+
+          playlist = oldPlaylist;
         } );
 
         test( "should reset uptime when a video plays", () => {
@@ -461,14 +467,23 @@
           assert.strictEqual( typeof element._watchdogTimer, "number" );
         } );
 
-        test( "should reset stuck video detection when video is played successfully", () => {
+        test( "should reset stuck video detection when video ends", () => {
           element._unstickAttempts = 999;
           element._lastCurrentTime = 999;
 
-          element._onPlay();
+          element._onEnded();
 
           assert.strictEqual( element._unstickAttempts, 0 );
           assert.strictEqual( element._lastCurrentTime, null );
+        } );
+
+        test( "should reset stuck video detection when video progresses", () => {
+          element._unstickAttempts = 999;
+          element._lastCurrentTime = 999;
+
+          element._watchdog();
+
+          assert.strictEqual( element._unstickAttempts, 0 );
         } );
       } );
     </script>


### PR DESCRIPTION
## Description

Fix for [Issue 32](https://github.com/Rise-Vision/rise-video/issues/32) ([Trello card](https://trello.com/c/hwLVVeSl))

## Motivation and Context

When playing large videos (ie: 4k) on a low-powered player (ie: a Raspberry Pi 3), the video playback sometimes becomes "stuck" indefinitely which prevents PUD from ever triggering.

This update attempts to "unstick" the video by detecting that the video timestamp hasn't progressed in some time and to pause and then play the video.

If this process fails a number of times, an error is logged to BQ and the video is skipped.

## How Has This Been Tested?

New unit and integrations tests have been added to cover the new functionality.

Code has been deployed [here](https://widgets.risevision.com/staging/components/rise-video/2019.09.05.08.43/rise-video.js) and added to a test template which is pre-configured with some large videos (one 4k and two 1080p) [here](https://widgets.risevision.com/staging/pages/2019.09.05.08.46/src/template.html) and manually tested by:

- Adding a low-powered player to [this schedule](https://apps.risevision.com/schedules/details/affc198c-62ad-48df-8e72-bc9e13c3395e?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f).
- Waiting some amount of time and observing that `watchdog: video stuck` is logged to the console and that the 4k background video keeps playing, even if extremely slowly. 

**Note:** This may take several minutes to several hours, or never occur at all, depending on the device. Also, since implementing the logic to "unstick" the videos I haven't been able to observe a video exceeding the max number of unstick attempts which leads me to believe the fix is successful, but I'll be leaving this running on a number of devices over the weekend to see if anything comes up before we do the merge next week.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Code will not be merged until Monday
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?

No release checklist items were skipped.

