### PR TITLE
Fix/issue 36 initial volume

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-video",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Web component for playing video files on a Rise Vision Template page",
   "scripts": {
     "prebuild": "eslint .",

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -330,10 +330,10 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
 
     this._playerInstance.play().catch( e => {
       if ( e.name === "NotAllowedError" ) {
-        console.log( "Autoplay of videos with sound not allowed, muting" );
+        console.log( "Autoplay of videos with sound not allowed, muting video" );
         this._playerInstance.muted( true );
       }
-      this._playerInstance.play();
+      this._playerInstance.play().catch( () => {} );
     });
   }
 

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -328,8 +328,11 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
       this._playerInstance.playlist.first();
     }
 
-    this._playerInstance.play().catch( () => {
-      this._playerInstance.muted( true );
+    this._playerInstance.play().catch( e => {
+      if ( e.name === "NotAllowedError" ) {
+        console.log( "Autoplay of videos with sound not allowed, muting" );
+        this._playerInstance.muted( true );
+      }
       this._playerInstance.play();
     });
   }

--- a/test/integration/rise-video-player.html
+++ b/test/integration/rise-video-player.html
@@ -301,7 +301,7 @@
               assert.equal( element._unstickAttempts, 3 );
 
               done();
-            }, 400 );
+            }, 450 );
           } );
         } );
 

--- a/test/unit/rise-video-player.html
+++ b/test/unit/rise-video-player.html
@@ -302,6 +302,35 @@
           assert.equal( element._playerInstance.muted.callCount, 2 );
           assert.deepEqual( element._playerInstance.muted.lastCall.args, [ false ]  );
         } );
+
+        test( "throwing a NotAllowedError when calling play() should mute the video", done => {
+          const oldPlay = element._playerInstance.play;
+          element._playerInstance.play = sinon.stub().rejects("NotAllowedError");
+
+          element._playFirst();
+
+          setTimeout( () => {
+            assert.equal( element._playerInstance.muted.callCount, 1 );
+            assert.isOk( element._playerInstance.muted.calledWithExactly( true ) );
+
+            element._playerInstance.play = oldPlay;
+            done();
+          } );
+        } );
+
+        test( "throwing any other error when calling play() should not mute the video", done => {
+          const oldPlay = element._playerInstance.play;
+          element._playerInstance.play = sinon.stub().rejects("CustomError");
+
+          element._playFirst();
+
+          setTimeout( () => {
+            assert.strictEqual( element._playerInstance.muted.callCount, 0 );
+
+            element._playerInstance.play = oldPlay;
+            done();
+          } );
+        } );
       } );
 
       suite( "logging", () => {


### PR DESCRIPTION
## Description

Fix for [issue #36](https://github.com/Rise-Vision/rise-video/issues/36)

## Motivation and Context

Changes related to [this Trello card](https://trello.com/c/tqFSLbJy).

## How Has This Been Tested?

New unit tests have been added to cover this code.

Manual testing:

Code has been deployed [here](https://widgets.risevision.com/staging/components/rise-video/2019.09.10.12.27/rise-video.js) and an updated `example-video-component` template has been deployed to stable which points to this code.

A presentation has been created [here](https://apps.risevision.com/templates/edit/f3e2cc7c-1eea-4210-86af-2e46cef98f88/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f) which contains a video with audio and 100% volume set.

To test:

- Add your player to [this schedule](https://apps.risevision.com/schedules/details/2d169ab1-3f36-4f94-b957-a49fe1df71be?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f)
- Allow it to load and start playing video
- Add another presentation  to the schedule (or just clone the initial one) and press save
- Wait for player to restart the presentation
- Remove the second presentation and press save
- Wait for player to restart the presentation
- Observe that audio plays the first time
- Repeat multiple time to verify that fix is working

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?

No documentation update was required.
