### PR TITLE
Add filePath to video-stuck

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-video",
-  "version": "1.0.13",
+  "version": "1.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3850,7 +3850,7 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#cc6f379e1fca220f5708c700bdf67be799903938",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#11856524a75e5991338c2bcf0a58bc10d1f771d0",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@webcomponents/webcomponentsjs": "2.2.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-video",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Web component for playing video files on a Rise Vision Template page",
   "scripts": {
     "prebuild": "eslint .",
@@ -28,7 +28,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.10",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.1.1",
     "video.js": "7.6.0",
     "videojs-playlist": "4.3.1"
   },

--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -162,7 +162,10 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
       } else {
         this._onEnded();
         console.warn( "watchdog: max unstick attempts exceeded" );
-        this._log( RiseVideoPlayer.LOG_TYPE_WARNING, RiseVideoPlayer.EVENT_VIDEO_STUCK, { fileUrl: this._playerInstance.currentSrc() } );
+        this._log( RiseVideoPlayer.LOG_TYPE_WARNING, RiseVideoPlayer.EVENT_VIDEO_STUCK, {
+          filePath: this._getFilePathFromSrc( this._playerInstance.currentSrc() ),
+          currentSrc: this._playerInstance.currentSrc()
+        } );
       }
     } else if ( this._unstickAttempts > 0 ) {
       console.info( "watchdog: reset unstick attempts" );

--- a/test/integration/rise-video-player.html
+++ b/test/integration/rise-video-player.html
@@ -320,7 +320,11 @@
 
             setTimeout( () => {
               assert.strictEqual( element._onEnded.callCount, 1 );
-              assert.isOk( element._log.calledWithExactly( "warning", "video-stuck", { fileUrl: "./videos/test2-0.5s-noaudio.mp4" } ) );
+              debugger;
+              assert.isOk( element._log.calledWithExactly( "warning", "video-stuck", {
+                filePath: "test2-0.5s-noaudio.mp4",
+                currentSrc: "./videos/test2-0.5s-noaudio.mp4"
+              } ) );
 
               element._onEnded.restore();
               element._log.restore();


### PR DESCRIPTION
## Description

- Update `video-stuck` event to add more info
- Update `rise-common-component`

## Motivation and Context

It would be useful to include the `filePath` which includes the name of the actual video file, vs the path in RLS, in `video-stuck` messages.

Additionally, `rise-common-component` was out of date and this component would benefit from an update.

## How Has This Been Tested?

Automated tests have been updated.

As this is a simple tweak to a log message, no manual testing should be necessary before merging.

I will manually test after deploying to `beta` to ensure things are functioning as expected before deploying to `master`.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?

No release checklist items were skipped.