### PR TITLE
Bump major version for development of Video in Shared Schedules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1011,7 +1011,7 @@
       "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
       "requires": {
         "anymatch": "~3.1.1",
-        "braces": "~3.0.2",
+        "braces": "^2.3.1",
         "fsevents": "~2.1.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
@@ -1026,21 +1026,7 @@
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
         "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          }
+          "version": "^2.3.1"
         },
         "extend-shallow": {
           "version": "2.0.1",
@@ -1346,14 +1332,12 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.3",
         "request": "^2.88.0"
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "^1.2.3"
         }
       }
     },
@@ -1924,7 +1908,7 @@
       "requires": {
         "detect-file": "^1.0.0",
         "is-glob": "^4.0.0",
-        "micromatch": "^3.0.4",
+        "micromatch": "~4.0.2",
         "resolve-dir": "^1.0.1"
       },
       "dependencies": {
@@ -1939,9 +1923,6 @@
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
         "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -1963,7 +1944,8 @@
                 "is-extendable": "^0.1.0"
               }
             }
-          }
+          },
+          "version": "^2.3.1"
         },
         "debug": {
           "version": "2.6.9",
@@ -2168,49 +2150,7 @@
           "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         },
         "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
-          },
-          "dependencies": {
-            "braces": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-              "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-              "dev": true,
-              "requires": {
-                "fill-range": "^7.0.1"
-              }
-            },
-            "fill-range": {
-              "version": "7.0.1",
-              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-              "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-              "dev": true,
-              "requires": {
-                "to-regex-range": "^5.0.1"
-              }
-            },
-            "is-number": {
-              "version": "7.0.0",
-              "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-              "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-              "dev": true
-            },
-            "to-regex-range": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-              "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-              "dev": true,
-              "requires": {
-                "is-number": "^7.0.0"
-              }
-            }
-          }
+          "version": "~4.0.2"
         },
         "ms": {
           "version": "2.0.0",
@@ -2439,14 +2379,11 @@
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "micromatch": "^3.1.4",
+            "micromatch": "~4.0.2",
             "normalize-path": "^2.1.1"
           },
           "dependencies": {
             "braces": {
-              "version": "2.3.2",
-              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
               "requires": {
                 "arr-flatten": "^1.1.0",
                 "array-unique": "^0.3.2",
@@ -2457,7 +2394,8 @@
                 "snapdragon-node": "^2.0.1",
                 "split-string": "^3.0.2",
                 "to-regex": "^3.0.1"
-              }
+              },
+              "version": "^2.3.1"
             },
             "fill-range": {
               "version": "7.0.1",
@@ -2475,25 +2413,7 @@
               "dev": true
             },
             "micromatch": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-              "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-              "dev": true,
-              "requires": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.0.5"
-              },
-              "dependencies": {
-                "braces": {
-                  "version": "3.0.2",
-                  "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-                  "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-                  "dev": true,
-                  "requires": {
-                    "fill-range": "^7.0.1"
-                  }
-                }
-              }
+              "version": "~4.0.2"
             },
             "to-regex-range": {
               "version": "5.0.1",
@@ -2523,9 +2443,6 @@
           "dev": true
         },
         "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -2547,7 +2464,8 @@
                 "is-extendable": "^0.1.0"
               }
             }
-          }
+          },
+          "version": "^2.3.1"
         },
         "chokidar": {
           "version": "2.1.8",
@@ -2557,7 +2475,7 @@
           "requires": {
             "anymatch": "^2.0.0",
             "async-each": "^1.0.1",
-            "braces": "^2.3.2",
+            "braces": "^2.3.1",
             "fsevents": "^1.2.7",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
@@ -2570,22 +2488,7 @@
           },
           "dependencies": {
             "braces": {
-              "version": "2.3.2",
-              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-              "dev": true,
-              "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
-              }
+              "version": "^2.3.1"
             },
             "normalize-path": {
               "version": "3.0.0",
@@ -2975,9 +2878,7 @@
               }
             },
             "minimist": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+              "version": "^1.2.3"
             },
             "minipass": {
               "version": "2.9.0",
@@ -3004,15 +2905,11 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.3"
               },
               "dependencies": {
                 "minimist": {
-                  "version": "1.2.5",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-                  "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-                  "dev": true,
-                  "optional": true
+                  "version": "^1.2.3"
                 }
               }
             },
@@ -3161,16 +3058,12 @@
               "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
-                "minimist": "^1.2.0",
+                "minimist": "^1.2.3",
                 "strip-json-comments": "~2.0.1"
               },
               "dependencies": {
                 "minimist": {
-                  "version": "1.2.5",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-                  "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-                  "dev": true,
-                  "optional": true
+                  "version": "^1.2.3"
                 }
               }
             },
@@ -3403,17 +3296,11 @@
           "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         },
         "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
           "requires": {
             "picomatch": "^2.0.5"
           },
           "dependencies": {
             "braces": {
-              "version": "2.3.2",
-              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
               "requires": {
                 "arr-flatten": "^1.1.0",
                 "array-unique": "^0.3.2",
@@ -3425,9 +3312,11 @@
                 "snapdragon-node": "^2.0.1",
                 "split-string": "^3.0.2",
                 "to-regex": "^3.0.1"
-              }
+              },
+              "version": "^2.3.1"
             }
-          }
+          },
+          "version": "~4.0.2"
         },
         "ms": {
           "version": "2.0.0",
@@ -3450,14 +3339,11 @@
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
-            "micromatch": "^3.1.10",
+            "micromatch": "~4.0.2",
             "readable-stream": "^2.0.2"
           },
           "dependencies": {
             "braces": {
-              "version": "2.3.2",
-              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
               "requires": {
                 "arr-flatten": "^1.1.0",
                 "array-unique": "^0.3.2",
@@ -3468,7 +3354,8 @@
                 "snapdragon-node": "^2.0.1",
                 "split-string": "^3.0.2",
                 "to-regex": "^3.0.1"
-              }
+              },
+              "version": "^2.3.1"
             },
             "fill-range": {
               "version": "7.0.1",
@@ -3486,25 +3373,7 @@
               "dev": true
             },
             "micromatch": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-              "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-              "dev": true,
-              "requires": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.0.5"
-              },
-              "dependencies": {
-                "braces": {
-                  "version": "3.0.2",
-                  "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-                  "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-                  "dev": true,
-                  "requires": {
-                    "fill-range": "^7.0.1"
-                  }
-                }
-              }
+              "version": "~4.0.2"
             },
             "to-regex-range": {
               "version": "5.0.1",
@@ -4436,13 +4305,11 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
       "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.3"
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "^1.2.3"
         }
       }
     },
@@ -4652,7 +4519,7 @@
       "dev": true,
       "requires": {
         "findup-sync": "^2.0.0",
-        "micromatch": "^3.0.4",
+        "micromatch": "~4.0.2",
         "resolve": "^1.4.0",
         "stack-trace": "0.0.10"
       },
@@ -4668,9 +4535,6 @@
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
         "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -4692,7 +4556,8 @@
                 "is-extendable": "^0.1.0"
               }
             }
-          }
+          },
+          "version": "^2.3.1"
         },
         "debug": {
           "version": "2.6.9",
@@ -4845,14 +4710,11 @@
           "requires": {
             "detect-file": "^1.0.0",
             "is-glob": "^3.1.0",
-            "micromatch": "^3.0.4",
+            "micromatch": "~4.0.2",
             "resolve-dir": "^1.0.1"
           },
           "dependencies": {
             "braces": {
-              "version": "2.3.2",
-              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
               "requires": {
                 "arr-flatten": "^1.1.0",
                 "array-unique": "^0.3.2",
@@ -4862,7 +4724,8 @@
                 "snapdragon-node": "^2.0.1",
                 "split-string": "^3.0.2",
                 "to-regex": "^3.0.1"
-              }
+              },
+              "version": "^2.3.1"
             },
             "fill-range": {
               "version": "7.0.1",
@@ -4880,25 +4743,7 @@
               "dev": true
             },
             "micromatch": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-              "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-              "dev": true,
-              "requires": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.0.5"
-              },
-              "dependencies": {
-                "braces": {
-                  "version": "3.0.2",
-                  "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-                  "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-                  "dev": true,
-                  "requires": {
-                    "fill-range": "^7.0.1"
-                  }
-                }
-              }
+              "version": "~4.0.2"
             },
             "to-regex-range": {
               "version": "5.0.1",
@@ -4980,49 +4825,7 @@
           "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         },
         "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
-          },
-          "dependencies": {
-            "braces": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-              "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-              "dev": true,
-              "requires": {
-                "fill-range": "^7.0.1"
-              }
-            },
-            "fill-range": {
-              "version": "7.0.1",
-              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-              "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-              "dev": true,
-              "requires": {
-                "to-regex-range": "^5.0.1"
-              }
-            },
-            "is-number": {
-              "version": "7.0.0",
-              "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-              "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-              "dev": true
-            },
-            "to-regex-range": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-              "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-              "dev": true,
-              "requires": {
-                "is-number": "^7.0.0"
-              }
-            }
-          }
+          "version": "~4.0.2"
         },
         "ms": {
           "version": "2.0.0",
@@ -5098,13 +4901,11 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
       "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.3"
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "^1.2.3"
         }
       }
     },
@@ -5161,22 +4962,18 @@
           }
         },
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "^1.2.3"
         },
         "mkdirp": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.3"
           },
           "dependencies": {
             "minimist": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+              "version": "^1.2.3"
             }
           }
         },
@@ -5508,14 +5305,12 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "~0.0.1",
+        "minimist": "^1.2.3",
         "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "^1.2.3"
         }
       }
     },
@@ -6611,28 +6406,20 @@
       "integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
       "requires": {
         "arrify": "^1.0.1",
-        "micromatch": "^2.3.11",
+        "micromatch": "~4.0.2",
         "object-assign": "^4.1.0",
         "read-pkg-up": "^1.0.1",
         "require-main-filename": "^1.0.1"
       },
       "dependencies": {
         "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "requires": {
             "fill-range": "^7.0.1"
-          }
+          },
+          "version": "^2.3.1"
         },
         "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
-          }
+          "version": "~4.0.2"
         },
         "require-main-filename": {
           "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-video",
-  "version": "1.0.19",
+  "version": "2.0.0",
   "description": "Web component for playing video files on a Rise Vision Template page",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",


### PR DESCRIPTION
## Description
Bumping major version of component so deployment doesn't overwrite current stable version being used by existing templates and instead deploys to version `2/` folder on GCS

## Motivation and Context
Work will be commencing on the component now playing videos in Template Editor Preview and Shared Schedules. In order to work on development, test, and release small incremental changes, we need to ensure the changes are not applied to current stable version. Instead we can test with a new major version of component in staged templates that use video component. 

## How Has This Been Tested?
n/a

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
