### PR TITLE
Enable flow for handling a start when running in preview

### DIFF
--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -122,6 +122,11 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     this._reset();
   }
 
+  _handleStartForPreview() {
+    // TODO: continue progress here
+    console.log("_handleStartForPreview()", this._validFiles);
+  }
+
   _handleStart() {
     if ( this._initialStart ) {
       this._initialStart = false;
@@ -135,11 +140,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   _start() {
     let filesList;
 
-    if ( this._isPreview ) {
-      return;
-    }
-
-    this.stopWatch();
+    super.stopWatch();
     this._clearFirstDownloadTimer();
     this._clearHandleNoFilesTimer();
 
@@ -149,7 +150,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
       filesList = this._getDefaultFiles();
     }
 
-    const { validFiles } = this.validateFiles( filesList, VALID_FILE_TYPES );
+    const { validFiles } = super.validateFiles( filesList, VALID_FILE_TYPES );
 
     if ( filesList && filesList.length && ( !validFiles || !validFiles.length ) ) {
       // there are some files, but all formats are invalid
@@ -158,6 +159,10 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
 
     if ( validFiles && validFiles.length > 0 ) {
       this._validFiles = validFiles;
+
+      if ( this._isPreview ) {
+        return this._handleStartForPreview();
+      }
 
       this.startWatch( validFiles );
 

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -140,7 +140,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   _start() {
     let filesList;
 
-    super.stopWatch();
+    this.stopWatch();
     this._clearFirstDownloadTimer();
     this._clearHandleNoFilesTimer();
 
@@ -150,7 +150,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
       filesList = this._getDefaultFiles();
     }
 
-    const { validFiles } = super.validateFiles( filesList, VALID_FILE_TYPES );
+    const { validFiles } = this.validateFiles( filesList, VALID_FILE_TYPES );
 
     if ( filesList && filesList.length && ( !validFiles || !validFiles.length ) ) {
       // there are some files, but all formats are invalid

--- a/test/unit/rise-video.html
+++ b/test/unit/rise-video.html
@@ -295,8 +295,14 @@
           assert.equal( RisePlayerConfiguration.isPreview.callCount, 1 );
         } );
 
-        test( "should not initialize if in preview mode", () => {
-          assert.deepEqual( element._validFiles, [] );
+        test( "should initialize valid files and call _handleStartForPreview()", () => {
+          sinon.spy(element, "_handleStartForPreview")
+          element._start();
+
+          assert.deepEqual( element._validFiles, ["test1.mp4", "test3.webm"] );
+          assert.isTrue(element._handleStartForPreview.called);
+
+          element._handleStartForPreview.restore();
         } );
 
       } );


### PR DESCRIPTION
## Description
Enable the flow of handling a `_start` method when running in _preview_. 

Ensuring to stop flow before the _startWatch()_ of files occur as this path of functionality is for running on Rise Player. 

## Motivation and Context
Small incremental steps to video component running in Editor Preview and Shared Schedules

## How Has This Been Tested?
Tested with template in apps https://apps.risevision.com/templates/edit/fc5e52c2-c5aa-430e-966c-a959909f9449/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f using Charles to map to local file of component. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
