### PR TITLE
Configure status for preview files so watchFilesMixin can manage a list

### DIFF
--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -123,8 +123,11 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   }
 
   _handleStartForPreview() {
-    // TODO: continue progress here
-    console.log("_handleStartForPreview()", this._validFiles);
+    this._validFiles.forEach( file => {
+      const status = this._previewStatusFor( file );
+
+      console.log("preview status: ", file, status);
+    });
   }
 
   _handleStart() {
@@ -182,6 +185,20 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
     this.stopWatch();
     this._clearFirstDownloadTimer();
     this._clearHandleNoFilesTimer();
+  }
+
+  _metadataEntryFor( file ) {
+    return this.metadata.find( current => current.file === file );
+  }
+
+  _previewStatusFor( file ) {
+    if ( !this._hasMetadata()) {
+      return "current";
+    }
+
+    const entry = this._metadataEntryFor( file );
+
+    return entry && entry.exists ? "current" : "deleted";
   }
 
   _configureShowingVideos() {

--- a/test/unit/rise-video.html
+++ b/test/unit/rise-video.html
@@ -608,6 +608,63 @@
         } );
       } );
 
+      suite( "_previewStatusFor", () => {
+        test( "should get current status if there is no metadata", () => {
+
+          const status = element._previewStatusFor( "risemedialibrary-abc123/test1.webm" );
+
+          assert.equal( status, "current" );
+        });
+
+        test( "should get current status if metadata says that file exists", () => {
+          element.metadata = [{
+            "file": "risemedialibrary-abc123/test1.webm",
+            "exists": true
+          }, {
+            "file": "risemedialibrary-abc123/test2.webm",
+            "exists": true
+          }];
+
+          const status = element._previewStatusFor( "risemedialibrary-abc123/test2.webm" );
+
+          assert.equal( status, "current" );
+        });
+
+        test( "should get deleted status if metadata says that file doesn't exist", () => {
+          element.metadata = [{
+            "file": "risemedialibrary-abc123/test1.webm",
+            "exists": true
+          }, {
+            "file": "risemedialibrary-abc123/test2.webm",
+            "exists": false
+          }];
+
+          const status = element._previewStatusFor( "risemedialibrary-abc123/test2.webm" );
+
+          assert.equal( status, "deleted" );
+        });
+
+        test( "should get deleted status if metadata is not empty but does not contain the file", () => {
+          element.metadata = [{
+            "file": "risemedialibrary-abc123/test1.webm",
+            "exists": true
+          }];
+
+          const status = element._previewStatusFor( "risemedialibrary-abc123/test2.webm" );
+
+          assert.equal( status, "deleted" );
+        } );
+
+        test( "should get deleted status if metadata is empty", () => {
+          element.metadata = [];
+
+          const status = element._previewStatusFor( "risemedialibrary-abc123/test1.webm" );
+
+          assert.equal( status, "deleted" );
+        });
+
+      });
+
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Description
Add function for configuring _status_ value of file(s) for preview so WatchFilesMixin can manage list accordingly

## Motivation and Context
Small incremental changes to have video component play videos in Editor Preview and Shared Schedules

## How Has This Been Tested?
Tested with template in apps https://apps.risevision.com/templates/edit/fc5e52c2-c5aa-430e-966c-a959909f9449/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f using Charles to map to local file of component.

Added unit tests

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
