### PR TITLE
Manage and play files on preview

### DIFF
--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -123,11 +123,11 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
   }
 
   _handleStartForPreview() {
-    this._validFiles.forEach( file => {
-      const status = this._previewStatusFor( file );
-
-      console.log("preview status: ", file, status);
-    });
+    this._validFiles.forEach( file => this.handleFileStatusUpdated({
+      filePath: file,
+      fileUrl: this._getFileUrl( file ),
+      status: this._previewStatusFor( file )
+    }));
   }
 
   _handleStart() {
@@ -138,6 +138,20 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseEle
 
       this._start();
     }
+  }
+
+  _getFileUrl( file ) {
+    return RiseVideo.STORAGE_PREFIX + this._encodePath( file );
+  }
+
+  _encodePath( filePath ) {
+    // encode each element of the path separately
+
+    let encodedPath = filePath.split("/")
+      .map( pathElement => encodeURIComponent( pathElement ))
+      .join("/");
+
+    return encodedPath;
   }
 
   _start() {

--- a/test/unit/rise-video.html
+++ b/test/unit/rise-video.html
@@ -609,6 +609,10 @@
       } );
 
       suite( "_previewStatusFor", () => {
+        setup( () => {
+          element = fixture( "test-block" );
+        } );
+
         test( "should get current status if there is no metadata", () => {
 
           const status = element._previewStatusFor( "risemedialibrary-abc123/test1.webm" );
@@ -664,6 +668,68 @@
         });
 
       });
+
+      suite( "_getFileUrl", () => {
+        setup( () => {
+          element = fixture( "test-block" );
+        } );
+
+        test( "should encode file path", () => {
+          let filePath = "risemedialibrary-abc123/testing/Ü-+ test%20encoding ([!@?,#$])=1+2-A&%.webm";
+          let fileUrl = element._getFileUrl( filePath );
+
+          assert.isTrue(fileUrl.indexOf("/risemedialibrary-abc123/") > 0, "forward slash in file path is not encoded" );
+        } );
+
+      } );
+
+      suite( "_handleStartForPreview", () => {
+        setup( () => {
+          element = fixture( "test-block" );
+          sinon.stub(element.__proto__.__proto__, "handleFileStatusUpdated");
+        });
+
+        teardown( () => {
+          element.metadata = null;
+
+          element.handleFileStatusUpdated.restore();
+        } );
+
+        test( "should call handleFileStatusUpdated with correct data", () => {
+          element._validFiles = [ "risemedialibrary-abc123/test.webm" ];
+          element._handleStartForPreview();
+
+          assert.isTrue( element.handleFileStatusUpdated.calledWith({
+            filePath: "risemedialibrary-abc123/test.webm",
+            fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test.webm",
+            status: "current"
+          } ));
+        } );
+
+        test( "should call handleFileStatusUpdated for each file", () => {
+          element._validFiles = [ "risemedialibrary-abc123/test1.webm", "risemedialibrary-abc123/test2.webm", "risemedialibrary-abc123/test3.webm" ];
+          element._handleStartForPreview();
+
+          assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[0][0], {
+            filePath: "risemedialibrary-abc123/test1.webm",
+            fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test1.webm",
+            status: "current"
+          } );
+
+          assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[1][0], {
+            filePath: "risemedialibrary-abc123/test2.webm",
+            fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test2.webm",
+            status: "current"
+          } );
+
+          assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[2][0], {
+            filePath: "risemedialibrary-abc123/test3.webm",
+            fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test3.webm",
+            status: "current"
+          } );
+        } );
+
+      } );
 
     </script>
   </body>


### PR DESCRIPTION
## Description
Add functionality to leverage _WatchFilesMixin_ for managing and playing a list of files for preview. 

**Reminder**
Component will deploy to version 2 on GCS which is not the production version being used by templates. No impact to users when merging these changes.

## Motivation and Context
Small incremental changes to have video component play videos in Editor Preview and Shared Schedules

## How Has This Been Tested?
Tested with template in apps https://apps.risevision.com/templates/edit/fc5e52c2-c5aa-430e-966c-a959909f9449/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f using Charles to map to local file of component.

Added unit tests

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
