### PR TITLE
Setup sequential processing of video files for initializing video player in Shared Schedules

### DIFF
--- a/test/integration/rise-video.html
+++ b/test/integration/rise-video.html
@@ -73,6 +73,7 @@
           element = fixture("test-block");
           element._maximumTimeForFirstDownload = 500;
           element._noFilesDoneDelay = 500;
+          element.dispatchEvent( new CustomEvent( "start" ) );
         } );
 
         test( "should wait for the correct amount of time when no files are received before emitting report-done", done => {
@@ -171,6 +172,7 @@
             handler( { status: "CURRENT", filePath: file, fileUrl: sampleUrl( file ) } );
           } );
           element = fixture("test-block-skip-init");
+          element.dispatchEvent( new CustomEvent( "start" ) );
         } );
 
         teardown( () => {
@@ -218,6 +220,7 @@
       suite( "child events", () => {
         setup (() => {
           element = fixture("test-block");
+          element.dispatchEvent( new CustomEvent( "start" ) );
         } );
 
         test( "should successfully pass logs to parent and then to Logger", () => {

--- a/test/unit/rise-video.html
+++ b/test/unit/rise-video.html
@@ -337,7 +337,7 @@
         } );
 
         test( "should initialize valid files and call _handleStartForPreview()", () => {
-          sinon.spy(element, "_handleStartForPreview")
+          sinon.stub(element, "_handleStartForPreview")
           element._start();
 
           assert.deepEqual( element._validFiles, ["test1.mp4", "test3.webm"] );
@@ -775,6 +775,172 @@
           } );
         } );
 
+      } );
+
+      suite( "_fetchVideosForPreview", () => {
+        setup( () => {
+          element = fixture( "test-block" );
+
+          sinon.stub(element, "_fetchFileForPreview").callsFake((file) => {
+            return Promise.resolve(`blob:${file.fileUrl}`);
+          });
+        });
+
+        teardown( () => {
+          element._fetchFileForPreview.restore();
+        } );
+
+        test( "should sequentially add files to _filesToRenderList array and complete with the array fully populated", (done) => {
+          const files = [
+            { filePath: "a.webm", fileUrl: "https://test.com/a.webm" },
+            { filePath: "b.webm", fileUrl: "https://test.com/b.webm" },
+            { filePath: "c.webm", fileUrl: "https://test.com/c.webm" }
+          ];
+
+          element._fetchVideosForPreview( files )
+            .then( () => {
+              assert.isTrue(element._fetchingVideosForPreview);
+              assert.equal(element._fetchFileForPreview.callCount, 3);
+              assert.deepEqual(element._filesToRenderList, [
+                { filePath: "a.webm", fileUrl: "blob:https://test.com/a.webm" },
+                { filePath: "b.webm", fileUrl: "blob:https://test.com/b.webm" },
+                { filePath: "c.webm", fileUrl: "blob:https://test.com/c.webm" }
+              ]);
+              done();
+            })
+            .catch(err => {
+              console.log("shouldn't be here", err);
+              assert.fail();
+              done();
+            });
+        } );
+
+        test( "should not add files to _filesToRenderList array if abort flag is on", (done) => {
+          const files = [
+            { filePath: "a.webm", fileUrl: "https://test.com/a.webm" },
+            { filePath: "b.webm", fileUrl: "https://test.com/b.webm" },
+            { filePath: "c.webm", fileUrl: "https://test.com/c.webm" }
+          ];
+
+          element._abortFetchingVideosForPreview = true;
+          element._fetchVideosForPreview( files )
+          .then( () => {
+            assert.isFalse(element._fetchFileForPreview.called);
+            assert.deepEqual(element._filesToRenderList, []);
+
+            done();
+          } )
+            .catch(err => {
+              console.log("shouldn't be here", err);
+              assert.fail();
+              done();
+            });
+        } );
+
+        test( "should not add file to _filesToRenderList array if abort flag turned on while processing a fetch", (done) => {
+          const files = [
+            { filePath: "a.webm", fileUrl: "https://test.com/a.webm" },
+            { filePath: "b.webm", fileUrl: "https://test.com/b.webm" },
+            { filePath: "c.webm", fileUrl: "https://test.com/c.webm" }
+          ];
+
+          element._fetchFileForPreview.restore();
+          sinon.stub(element, "_fetchFileForPreview").callsFake((file) => {
+            if ( element._fetchFileForPreview.callCount > 1 ) {
+              element._abortFetchingVideosForPreview = true;
+            }
+
+            return Promise.resolve(`blob:${file.fileUrl}`);
+          });
+
+          element._fetchVideosForPreview( files )
+            .then( () => {
+              assert.equal(element._fetchFileForPreview.callCount, 2);
+              assert.deepEqual(element._filesToRenderList, [
+                { filePath: "a.webm", fileUrl: "blob:https://test.com/a.webm" }
+              ]);
+
+              done();
+            } )
+            .catch(err => {
+              console.log("shouldn't be here", err);
+              assert.fail();
+              done();
+            });
+        } );
+      } );
+
+      suite( "_configureShowingVideosForPreview", () => {
+        setup( () => {
+
+          element = fixture( "test-block" );
+
+          sinon.stub(element, "_fetchVideosForPreview").callsFake(() => {
+            element._fetchingVideosForPreview = true;
+
+            return Promise.resolve();
+          });
+        });
+
+        teardown( () => {
+          element._fetchVideosForPreview.restore();
+
+        } );
+
+        test( "should not execute if presentation has not started", () => {
+          element._presentationStarted = false;
+          element._configureShowingVideosForPreview();
+
+          assert.isFalse(element._fetchVideosForPreview.called);
+        } );
+
+        test( "should recursively wait to execute until previous sequential fetch is complete based on flag", () => {
+          let clock = sinon.useFakeTimers();
+
+          sinon.spy(element, "_configureShowingVideosForPreview");
+
+          element._presentationStarted = true;
+          element._fetchingVideosForPreview = true;
+          element._configureShowingVideosForPreview();
+
+          clock.tick(500);
+          assert.equal(element._configureShowingVideosForPreview.callCount, 2);
+          assert.isFalse(element._fetchVideosForPreview.called);
+
+          clock.tick(500);
+          assert.equal(element._configureShowingVideosForPreview.callCount, 3);
+          assert.isFalse(element._fetchVideosForPreview.called);
+
+          // mock previous sequential fetching completed
+          element._fetchingVideosForPreview = false;
+
+          clock.tick(500);
+          assert.equal(element._configureShowingVideosForPreview.callCount, 4);
+          assert.isTrue(element._fetchVideosForPreview.called);
+
+          clock.restore();
+        } );
+
+        test( "should call _fetchVideosForPreview with managed files and set flags when complete", (done) => {
+          const files = [
+            { filePath: "a.webm", fileUrl: "https://test.com/a.webm" },
+            { filePath: "b.webm", fileUrl: "https://test.com/b.webm" },
+            { filePath: "c.webm", fileUrl: "https://test.com/c.webm" }
+          ];
+
+          element._presentationStarted = true;
+          element.managedFiles = files;
+          element._configureShowingVideosForPreview();
+
+          setTimeout(() => {
+            assert.isTrue(element._fetchVideosForPreview.calledWith(files));
+            assert.isFalse(element._fetchingVideosForPreview);
+            assert.isFalse(element._abortFetchingVideosForPreview);
+
+            done()
+          }, 200);
+
+        } );
       } );
 
     </script>

--- a/test/unit/rise-video.html
+++ b/test/unit/rise-video.html
@@ -211,18 +211,24 @@
         } );
 
         test( "watched files are updated when files property changes", () => {
+          element.dispatchEvent( new CustomEvent( "start" ) );
+
           element.files = "foo.mp4|bar.webm|baz.jpg";
 
           assert.deepEqual( element.managedFiles, [ { filePath: "foo.mp4", fileUrl: sampleUrl("foo.mp4"), order: 0 }, { filePath: "bar.webm", fileUrl: sampleUrl("bar.webm"), order: 1 } ] );
         });
 
         test( "watched files are updated when metadata property changes", () => {
+          element.dispatchEvent( new CustomEvent( "start" ) );
+
           element.metadata = [ { file: "foo.mp4" }, { file: "bar.webm" }, { file: "baz.jpg" } ];
 
           assert.deepEqual( element.managedFiles, [ { filePath: "foo.mp4", fileUrl: sampleUrl("foo.mp4"), order: 0 }, { filePath: "bar.webm", fileUrl: sampleUrl("bar.webm"), order: 1 } ] );
         });
 
         test( "_filesToRenderList is updated correctly when metadata has no files", () => {
+          element.dispatchEvent( new CustomEvent( "start" ) );
+
           assert.strictEqual( element._filesToRenderList.length, 2);
 
           element.metadata = [];
@@ -247,6 +253,8 @@
         } );
 
         test( "_filesToRenderList should not contain watched files which are returned after they're no longer needed", done => {
+          element.dispatchEvent( new CustomEvent( "start" ) );
+
           element.metadata = [ {file: "newFile1.mp4"}, {file: "newFile2.mp4"} ];
 
           setTimeout( () => {
@@ -280,6 +288,8 @@
         setup( () => {
           sinon.stub(RisePlayerConfiguration.Helpers, "isEditorPreview").returns(true);
           element = fixture( "test-block" );
+
+          element.dispatchEvent( new CustomEvent( "start" ) );
         } );
 
         teardown( () => {
@@ -387,6 +397,7 @@
       suite( "play until done", () => {
         setup( () => {
           element = fixture( "test-block" );
+          element.dispatchEvent( new CustomEvent( "start" ) );
         } );
 
         test( "should not set up files done timer if no files are provided", () => {
@@ -467,6 +478,7 @@
         setup( () => {
           sinon.stub( RisePlayerConfiguration.LocalStorage, 'watchSingleFile').callsFake( () => {} );
           element = fixture( "test-block" );
+          element.dispatchEvent( new CustomEvent( "start" ) );
         } );
 
         teardown( () => {
@@ -497,6 +509,7 @@
       suite( "presentation-events", () => {
         setup( () => {
           element = fixture( "test-block" );
+          element.dispatchEvent( new CustomEvent( "start" ) );
         } );
 
         test( "calling _stop should clear timeouts and stop playing videos", () => {
@@ -538,6 +551,8 @@
         setup( () => {
           element = fixture( "test-block" );
           sinon.spy( element, "_setUptimeError" );
+
+          element.dispatchEvent( new CustomEvent( "start" ) );
         } );
 
         teardown( () => {


### PR DESCRIPTION
## Description
When running in "preview" (Shared Schedules), component now sequentially fetches each file in list until all are completed.

During this sequential processing, when a file fetch is complete, the files for rendering Array is updated which is what `video-player` child component observes for applying a playlist to the VideoJS playlist instance. 

Temporarily not using `StoreFilesMixin` to manage fetching and caching the file, waiting until that mechanism is finalized from Image component work. Instead for now just emulating a delay and using the storage file url as opposed to an object url so this sequential processing can be developed and tested. 

The sequence ensures to also check an abort flag to prevent further fetching and updating files for rendering Array. This is to account for default file list getting processed and then a reset occurs from a metadata update, in which case the component needs to execute the sequential processing again with the revised list. Another flag is set to ensure the previous sequence completes before starting the new one. 

Also fixed `_reset` function to **only** execute if it is not the _initial start_ of the component, which is now consistent with other components. Previously the component was executing `_start` function multiple times due to the several ways `_reset` can be triggered in the beginning lifecycle of the component. 

**Note**
There are a few more things to handle post this PR:

- setup and handle first file download timer (only allow so long before calling Done) which is consistent with running on a display
- handle when metadata indicates a file does not exist
- use StoreFilesMixin to fetch files


## Motivation and Context
Small incremental steps to caching video files in Browser to support running in Shared Schedules. 

## How Has This Been Tested?
Tested in [Shared Schedules](https://preview.risevision.com/?type=sharedschedule&id=822cbbd2-ad76-44c1-acc6-cff355e1c133) from this [presentation](https://apps.risevision.com/templates/edit/fc5e52c2-c5aa-430e-966c-a959909f9449/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f) using Charles to:

- map to local common-template build as I needed to remove video from the list of unsupported components
- map to local video component

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
