### PR TITLE
Filter out files flagged as non existent when running for preview

### DIFF
--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -150,8 +150,16 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( base ) 
     this._validFiles.forEach( file => this.handleFileStatusUpdated({
       filePath: file,
       fileUrl: this._getFileUrl( file ),
-      status: this._previewStatusFor( file )
+      status: "current"
     }));
+  }
+
+  _filterDeletedFilesForPreview( files ) {
+    if ( !files || !Array.isArray( files ) ) {
+      return [];
+    }
+
+    return files.filter( file => this._previewStatusFor( file ) !== "deleted" );
   }
 
   _handleStart() {
@@ -201,11 +209,15 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( base ) 
       filesList = this._getDefaultFiles();
     }
 
-    const { validFiles } = this.validateFiles( filesList, VALID_FILE_TYPES );
+    let { validFiles } = this.validateFiles( filesList, VALID_FILE_TYPES );
 
     if ( filesList && filesList.length && ( !validFiles || !validFiles.length ) ) {
       // there are some files, but all formats are invalid
       this._setUptimeError( true );
+    }
+
+    if ( this._isPreview ) {
+      validFiles = this._filterDeletedFilesForPreview( validFiles );
     }
 
     if ( validFiles && validFiles.length > 0 ) {

--- a/test/unit/rise-video.html
+++ b/test/unit/rise-video.html
@@ -337,12 +337,15 @@
         } );
 
         test( "should initialize valid files and call _handleStartForPreview()", () => {
-          sinon.stub(element, "_handleStartForPreview")
+          sinon.stub(element, "_handleStartForPreview");
+          sinon.spy(element, "_filterDeletedFilesForPreview");
           element._start();
 
+          assert.isTrue(element._filterDeletedFilesForPreview.calledWith(["test1.mp4", "test3.webm"]));
           assert.deepEqual( element._validFiles, ["test1.mp4", "test3.webm"] );
           assert.isTrue(element._handleStartForPreview.called);
 
+          element._filterDeletedFilesForPreview.restore();
           element._handleStartForPreview.restore();
         } );
 
@@ -989,6 +992,32 @@
           assert.isFalse(element._done.called);
         } );
 
+      } );
+
+      suite( "_filterDeletedFilesForPreview", () => {
+        setup( () => {
+          element = fixture( "test-block" );
+        });
+
+        test( "should return empty array if files param is invalid", () => {
+          assert.deepEqual(element._filterDeletedFilesForPreview(), []);
+          assert.deepEqual(element._filterDeletedFilesForPreview("test"), []);
+          assert.deepEqual(element._filterDeletedFilesForPreview(123), []);
+        } );
+
+        test( "should return list of files with deleted files filtered out as per metadata", () => {
+          element.metadata = [ { file: "test1.webm", exists: true }, { file: "test2.webm", exists: false }, { file: "test3.webm", exists: true } ];
+
+          assert.deepEqual(element._filterDeletedFilesForPreview(["test1.webm", "test2.webm", "test3.webm"]), [
+            "test1.webm", "test3.webm"
+          ]);
+        } );
+
+        test( "should return correct list of files when no metadata exists", () => {
+          const list = ["test1.webm", "test2.webm", "test3.webm"];
+
+          assert.deepEqual(element._filterDeletedFilesForPreview(list), list);
+        } );
       } );
 
     </script>


### PR DESCRIPTION
## Description
Relying on WatchFilesMixin to call `watchedFileDeletedCallback` is ideal for the flow of the component running on Display as its purpose is to react to realtime file updates via messaging from LocalStorage module. It is not ideal for the flow of the component running on Shared Schedules as the component only requires to manage the files its given at startup. 

These changes now account for scenario where metadata has flagged a file(s) as non existent and immediately filter them from the list of valid files so only files that exist are processed. 

## Motivation and Context
Small incremental steps to support video in Shared Schedules

## How Has This Been Tested?
Tested in Shared Schedules with Charles mapping to local common-template and video component sources. Created scenario by 

- Presentation has video component with several files in list
- Deleted one of the files from Storage
- Went back into presentation, saw the file marked as deleted, published the presentation
- Tested in Shared Schedules, file was never requested. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
