### PR TITLE
Use StoreFilesMixin to fetch files

### DIFF
--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -289,6 +289,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
       return;
     }
 
+    this._revokeObjectUrls( this.files );
     this._playerInstance.playlist( playlist );
 
     // simply setting an empty playlist will not stop the player from playing
@@ -394,6 +395,26 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
 
   _resetPlayer() {
     this._playerInstance.reset();
+  }
+
+  _revokeObjectUrls( newFilesList ) {
+    if ( !RisePlayerConfiguration.isPreview() || !newFilesList || !Array.isArray( newFilesList ) ) {
+      return;
+    }
+
+    if ( this._playerInstance && this._playerInstance.playlist && this._playerInstance.playlist() && this._playerInstance.playlist().length > 0 ) {
+      if ( newFilesList.length === 0 ) {
+        // new list is empty, we need to revoke all object urls in current playlist
+        return this._playerInstance.playlist().forEach(({sources}) => URL.revokeObjectURL(sources[0].src));
+      }
+
+      // find if a file in current playlist is in the new file list, if it's not then revoke the object url
+      this._playerInstance.playlist().forEach((item) => {
+        if ( !newFilesList.find( ({fileUrl}) => fileUrl === item.sources[0].src) ) {
+          URL.revokeObjectURL( item.sources[0].src );
+        }
+      });
+    }
   }
 }
 

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -134,6 +134,10 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( base ) 
     this.$.videoPlayer.addEventListener( "log", this._childLog );
     this.$.videoPlayer.addEventListener( "set-uptime", this._childSetUptime );
     this.$.videoPlayer.addEventListener( "playlist-done", () => this._done() );
+
+    super.initCache({
+      name: `${this.tagName.toLowerCase()}_v${version.charAt(0)}`
+    });
   }
 
   _stopPresentation() {
@@ -274,15 +278,15 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( base ) 
       .filter( f => this._validFiles.includes( f.filePath ) );
   }
 
-  _fetchFileForPreview( file ) {
-    // TODO: Use StoreFilesMixin to fetch and cache files. Waiting until StoreFilesMixin is in a reliable stable state
-
-    // temporarily emulating downloading/caching with a timeout as well as return the direct storage url instead of object url for now
-    return new Promise(( resolve ) => {
-      setTimeout(() => {
-        resolve( file.fileUrl );
-      }, 1000);
-    });
+  _fetchFileForPreview( fileUrl ) {
+    return super.getFile( fileUrl )
+      .then( objectUrl => {
+        if ( typeof objectUrl === "string" ) {
+          return objectUrl;
+        } else {
+          throw new Error( "Invalid file url!" );
+        }
+      });
   }
 
   _abortFetchingForPreview() {
@@ -302,7 +306,7 @@ export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( base ) 
           return;
         }
 
-        return this._fetchFileForPreview( file ).then( (objectUrl) => {
+        return this._fetchFileForPreview( file.fileUrl ).then( (objectUrl) => {
           // don't add this to render list if an abort is flagged
           if ( this._abortFetchingVideosForPreview ) {
             return;

--- a/test/unit/rise-video-player.html
+++ b/test/unit/rise-video-player.html
@@ -561,6 +561,50 @@
         } );
       } );
 
+      suite( "_revokeObjectUrls", () => {
+        const newFileList = [ { "fileUrl": "https://storage.googleapis.com/new1.mp4", "filePath": "new1.mp4" }, { "fileUrl": "https://storage.googleapis.com/new2.webm", "filePath": "new2.webm" } ];
+
+        setup(()=>{
+          sinon.stub(URL, "revokeObjectURL");
+        });
+
+        teardown(() => {
+          URL.revokeObjectURL.restore();
+        });
+
+        test( "should not execute under invalid conditions", () => {
+          // not running in preview
+          element._revokeObjectUrls();
+          assert.isFalse(URL.revokeObjectURL.called);
+
+          sinon.stub(RisePlayerConfiguration, "isPreview").returns(true);
+
+          // running in preview
+          element._revokeObjectUrls();
+          assert.isFalse(URL.revokeObjectURL.called);
+
+          element._revokeObjectUrls(123);
+          assert.isFalse(URL.revokeObjectURL.called);
+
+          element._revokeObjectUrls("test");
+          assert.isFalse(URL.revokeObjectURL.called);
+
+          // video player has no playlist
+          element._revokeObjectUrls(newFileList);
+          assert.isFalse(URL.revokeObjectURL.called);
+
+          RisePlayerConfiguration.isPreview.restore();
+        } );
+
+        test( "should revoke object urls of entire player playlist when files update is empty list", () => {
+          // TODO: could not find a way to manipulate playerInstance playlist to properly test this
+        } );
+
+        test( "should revoke object urls in player playlist that don't exist in new files list", () => {
+          // TODO: could not find a way to manipulate playerInstance playlist to properly test this
+        } );
+      } );
+
     </script>
   </body>
 </html>

--- a/test/unit/rise-video.html
+++ b/test/unit/rise-video.html
@@ -780,12 +780,55 @@
 
       } );
 
+      suite( "_fetchFileForPreview", () => {
+        setup( () => {
+          sinon.stub(element.__proto__.__proto__.__proto__, "getFile").resolves("test object url");
+        } );
+
+        teardown( () => {
+          element.__proto__.__proto__.__proto__.getFile.restore();
+        } );
+
+        test( "should make getFile() call of StoreFilesMixin with correct file url", () => {
+          element._fetchFileForPreview("https://storage.googleapis.com/risemedialibrary-abc123/test1.webm");
+
+          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-abc123/test1.webm"));
+        } );
+
+        test( "should return object url", (done) => {
+          element._fetchFileForPreview("https://storage.googleapis.com/risemedialibrary-abc123/test1.webm")
+          .then(objectUrl => {
+            assert.equal(objectUrl, "test object url");
+            done();
+          })
+          .catch(err => {
+            console.log("should not be here!", err);
+            assert.fail();
+          })
+        } );
+
+        test( "should throw an error if not an object url string", (done) => {
+          element.__proto__.__proto__.__proto__.getFile.restore();
+          sinon.stub(element.__proto__.__proto__.__proto__, "getFile").resolves(null);
+
+          element._fetchFileForPreview("https://storage.googleapis.com/risemedialibrary-abc123/test1.webm")
+            .then(objectUrl => {
+              console.log("shouldn't be here!", objectUrl);
+              assert.fail();
+            })
+            .catch(err => {
+              assert.equal(err.message, "Invalid file url!");
+              done();
+            });
+        } );
+      } );
+
       suite( "_fetchVideosForPreview", () => {
         setup( () => {
           element = fixture( "test-block" );
 
-          sinon.stub(element, "_fetchFileForPreview").callsFake((file) => {
-            return Promise.resolve(`blob:${file.fileUrl}`);
+          sinon.stub(element, "_fetchFileForPreview").callsFake((fileUrl) => {
+            return Promise.resolve(`blob:${fileUrl}`);
           });
           sinon.spy(element, "_clearFirstDownloadTimer");
         });
@@ -851,12 +894,12 @@
           ];
 
           element._fetchFileForPreview.restore();
-          sinon.stub(element, "_fetchFileForPreview").callsFake((file) => {
+          sinon.stub(element, "_fetchFileForPreview").callsFake((fileUrl) => {
             if ( element._fetchFileForPreview.callCount > 1 ) {
               element._abortFetchingVideosForPreview = true;
             }
 
-            return Promise.resolve(`blob:${file.fileUrl}`);
+            return Promise.resolve(`blob:${fileUrl}`);
           });
 
           element._fetchVideosForPreview( files )


### PR DESCRIPTION
## Description
Now using StoreFiles mixin to fetch video files and be given an object url as a part of the sequential processing to supply video player a playlist of files. 

Ensuring to also revoke object urls that are no longer used when it's appropriate:
 - when video player has a current playlist and receives a files update with an empty list, revokes all of the playlist object urls
 - when video player has a current playlist and receives a files update, it revokes playlist object urls that don't exist in the newly updated files list

## Motivation and Context
Small incremental steps to caching videos in browser to support Shared Schedules

## How Has This Been Tested?
Tested in Shared Schedules via Charles mapping to local common-template (remove filtering video templates) and local video component.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
