### PR TITLE
Add new dist file that points to polymer-bundle.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,14 +1,20 @@
 const concat = require("gulp-concat");
 const gulp = require("gulp");
 
-const bundle = "dist/rise-video.js";
+const bundles = [ 
+	"dist/rise-video.js", 
+	"dist/rise-video-bundle.min.js"
+];
 const dependencies = [
   "node_modules/video.js/dist/video.min.js",
   "node_modules/videojs-playlist/dist/videojs-playlist.min.js"
 ];
 
-gulp.task( "default", () => {
-  return gulp.src( dependencies.concat( bundle ) )
-    .pipe( concat( bundle ) )
-    .pipe( gulp.dest( "." ) );
+gulp.task( "default", (done) => {
+  bundles.map(function(file) {
+    return gulp.src( dependencies.concat( file ) )
+      .pipe( concat( file ) )
+      .pipe( gulp.dest( "." ) );
+  });
+  done();
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-video",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "Web component for playing video files on a Rise Vision Template page",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/Rise-Vision/rise-video/#readme",
   "dependencies": {
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.9.1",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.9.2",
     "video.js": "7.6.0",
     "videojs-playlist": "4.3.1"
   },


### PR DESCRIPTION
## Description
Adds an extra distribution file that references a static version of polymer and dependencies instead of relative to the template.

## Motivation and Context
Please check notes from: https://github.com/Rise-Vision/rise-common-component/pull/73

## How Has This Been Tested?
Confirmed the file exists and points to the static polymer-bundle: 
https://widgets.risevision.com/staging/components/rise-video/build-bundle/rise-video-bundle.min.js

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

@alexdeaconu Please review. 
@stulees @olegrise fyi
