### PR TITLE
Stage/issue 1858 embedded video autoplay

### DIFF
--- a/e2e/rise-video.html
+++ b/e2e/rise-video.html
@@ -4,6 +4,9 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>
+      window.env = { RISE_ENV: 'test' }
+    </script>
 
     <script src="https://widgets.risevision.com/scripts/primus-local-messaging.js"></script>
 

--- a/src/rise-video.js
+++ b/src/rise-video.js
@@ -11,20 +11,7 @@ export const VALID_FILE_TYPES = [ "mp4", "webm" ];
 export const MAXIMUM_TIME_FOR_FIRST_DOWNLOAD = 15 * 1000;
 export const NO_FILES_DONE_DELAY = 10 * 1000;
 
-// If running in Viewer, detect whether the template has been initially hidden
-// or not so we can prevent playback.
-
-let initiallyHidden = false;
-
-try {
-  if ( window.frameElement ) {
-    if (window.frameElement.parentElement.style.visibility === "hidden" ) {
-      initiallyHidden = true;
-    }
-  }
-} catch(e) {
-  console.log( "There was a problem accessing the parent document" );
-}
+let initiallyHidden = RisePlayerConfiguration.Helpers.isInViewer() && !RisePlayerConfiguration.Helpers.isTestEnvironment();
 
 export default class RiseVideo extends WatchFilesMixin( ValidFilesMixin( RiseElement ) ) {
   static get template() {

--- a/test/integration/dependencies.html
+++ b/test/integration/dependencies.html
@@ -13,6 +13,13 @@
     <script src="../../node_modules/chai/chai.js"></script>
     <script src="../../node_modules/sinon/pkg/sinon.js"></script>
     <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
+    <script type="text/javascript">
+      RisePlayerConfiguration = {
+        Helpers: {
+          isInViewer: () => false
+        }
+      };
+    </script>
     <script src="../../dist/rise-video.js"></script>
   </head>
   <body>

--- a/test/integration/rise-video-player.html
+++ b/test/integration/rise-video-player.html
@@ -21,7 +21,8 @@
 
       RisePlayerConfiguration = {
         Helpers: {
-          getComponentAsync: () => {}
+          getComponentAsync: () => {},
+          isInViewer: () => false
         },
         isPreview: () => false,
         Logger: {

--- a/test/integration/rise-video.html
+++ b/test/integration/rise-video.html
@@ -20,7 +20,8 @@
 
       RisePlayerConfiguration = {
         Helpers: {
-          getComponentAsync: () => {}
+          getComponentAsync: () => {},
+          isInViewer: () => false
         },
         isPreview: () => false,
         Logger: {

--- a/test/unit/rise-video-player.html
+++ b/test/unit/rise-video-player.html
@@ -25,7 +25,8 @@
 
       RisePlayerConfiguration = {
         Helpers: {
-          getComponentAsync: () => {}
+          getComponentAsync: () => {},
+          isInViewer: () => false
         },
         isPreview: () => false,
         Logger: {

--- a/test/unit/rise-video.html
+++ b/test/unit/rise-video.html
@@ -19,7 +19,8 @@
 
       RisePlayerConfiguration = {
         Helpers: {
-          getComponentAsync: () => {}
+          getComponentAsync: () => {},
+          isInViewer: () => false
         },
         isPreview: () => false,
         Logger: {

--- a/test/unit/utils.html
+++ b/test/unit/utils.html
@@ -10,6 +10,13 @@
     <script src="../../node_modules/mocha/mocha.js"></script>
     <script src="../../node_modules/chai/chai.js"></script>
     <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
+    <script type="text/javascript">
+      RisePlayerConfiguration = {
+        Helpers: {
+          isInViewer: () => false
+        }
+      };
+    </script>
   </head>
   <body>
 


### PR DESCRIPTION
## Description
This is the proposed fix for https://github.com/Rise-Vision/html-template-library/issues/1858

## Motivation and Context
rise-video component curently autoplays by default, but it prevents autoplay if it detects it's in viewer and if the tag in the parent iframe holding the component is not visible. In embedded templates, this check fails because the embedded templates has other layout that involves shadow dom, and a different lifecycle to show and hide embedded content.

As in viewer videos should not autoplay because the rise-presentation-play and rise-presentation-stop should have control, this change disables autoplay in viewer, with the exception of test scenarios ( such as E2E ).

## How Has This Been Tested?
Unit tests were updated to include the viewer check.
E2E was updated to set the test flag. E2E passed successfully - https://app.circleci.com/pipelines/github/Rise-Vision/rise-video/304/workflows/1b345900-e489-4d9a-a69c-76878de9bff2
I tested it worked correctly on both player Electron and ChromeOS player app with [this presentation](https://apps-stage-9.risevision.com/templates/edit/f743b1e8-f600-45b6-aabe-29d99ac47b97/?cid=121ae986-1b89-40c8-b10b-a64c60fb9e03) and [this schedule](https://apps-stage-9.risevision.com/schedules/details/4db24e51-1d5e-4468-b479-f573c584bf8a?cid=121ae986-1b89-40c8-b10b-a64c60fb9e03).

Both regular and embedded templates were tested, and combinations.

## Release Plan:
To be released on Thursday or Monday.
If there's a problem, a simple rollback is enough to undo the changes.}
Once released the defect will be closed and support will be notified as the report comes from them.

#### Release Checklist Items Skipped?
No need to update documentation.
