### PR TITLE
Prevent default poster from showing in certain cases

### DIFF
--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -39,7 +39,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
           display: none !important;
         }
       </style>
-      <video id="video" class="video-js"></video>
+      <video id="video" poster="noposter" class="video-js"></video>
     `;
   }
 


### PR DESCRIPTION
## Description
If the [poster](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-poster) attribute isn't specified, no image should be shown while the video is downloading. However, this is not always the case. For example, Android TV shows a grey play icon momentarily.

## Motivation and Context
Android player [issue 23](https://github.com/Rise-Vision/android-player/issues/23)

## How Has This Been Tested?
Confirmed in a [custom HTML template presentation](https://apps.risevision.com/templates/edit/3aaaed79-5ae8-4ddd-9890-64b0d274841e/?cid=) that the `poster="noposter"` attribute prevents the default grey play icon from showing on the Android TV Device, and results in no change for shared schedules.

## Release Plan:
- 100%