### PR TITLE
Fix no poster

### DIFF
--- a/src/rise-video-player.js
+++ b/src/rise-video-player.js
@@ -39,7 +39,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
           display: none !important;
         }
       </style>
-      <video id="video" poster="noposter" class="video-js"></video>
+      <video id="video" class="video-js"></video>
     `;
   }
 
@@ -309,7 +309,7 @@ export default class RiseVideoPlayer extends LoggerMixin( RiseElement ) {
       };
 
       sources.push( source );
-      playlistItem = { sources: sources };
+      playlistItem = { sources: sources, poster: "noposter" };
       playlist.push( playlistItem );
     } );
 

--- a/test/integration/rise-video-player.html
+++ b/test/integration/rise-video-player.html
@@ -176,6 +176,14 @@
           element = fixture("test-block");
         } );
 
+        test( "video poster should be off", done => {
+          element._playerInstance.on( "play", () => {
+            assert.strictEqual( element._playerInstance.poster(), "noposter" );
+
+            done();
+          } );
+        } );
+
         test( "player volume should default to 0 and be muted intially", done => {
           element._playerInstance.on( "play", () => {
             assert.strictEqual( element._playerInstance.volume(), 0 );

--- a/test/unit/rise-video-player.html
+++ b/test/unit/rise-video-player.html
@@ -212,8 +212,8 @@
       suite( "_initPlaylist", () => {
         test( "playlist should be initialized correctly", () => {
           const expected = [
-            { sources: [ { src: sampleUrl( FILES[0]), type: sampleType( FILES[0] ) } ] },
-            { sources: [ { src: sampleUrl( FILES[1]), type: sampleType( FILES[1] ) } ] }
+            { sources: [ { src: sampleUrl( FILES[0]), type: sampleType( FILES[0] ) } ], poster: "noposter" },
+            { sources: [ { src: sampleUrl( FILES[1]), type: sampleType( FILES[1] ) } ], poster: "noposter" }
           ];
 
           element._playerInstance.playlist.resetHistory();


### PR DESCRIPTION
## Description
[Previous](https://github.com/Rise-Vision/rise-video/pull/85) noposter fix is not working with videojs playlist.

This fixes it correctly and confirms with corrected unit test as well as additional integration test.

## Motivation and Context
Android player [issue 23](https://github.com/Rise-Vision/android-player/issues/23)

## How Has This Been Tested?
Confirmed video element is receiving the poster attribute using integration test and manual inspection of element in devtools.

